### PR TITLE
Silence py3 warnings about files left open.

### DIFF
--- a/src/git/middle.py
+++ b/src/git/middle.py
@@ -10,7 +10,8 @@ def get_expanded_variables(versionfile_source):
     # used from _version.py.
     variables = {}
     try:
-        for line in open(versionfile_source,"r").readlines():
+        f = open(versionfile_source,"r")
+        for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
                 if mo:
@@ -19,6 +20,7 @@ def get_expanded_variables(versionfile_source):
                 mo = re.search(r'=\s*"(.*)"', line)
                 if mo:
                     variables["full"] = mo.group(1)
+        f.close()
     except EnvironmentError:
         pass
     return variables

--- a/src/trailer.py
+++ b/src/trailer.py
@@ -27,6 +27,7 @@ def versions_from_file(filename):
         mo = re.match("version_full = '([^']+)'", line)
         if mo:
             versions["full"] = mo.group(1)
+    f.close()
     return versions
 
 def write_to_version_file(filename, versions):

--- a/versioneer.py
+++ b/versioneer.py
@@ -144,7 +144,8 @@ def get_expanded_variables(versionfile_source):
     # used from _version.py.
     variables = {}
     try:
-        for line in open(versionfile_source,"r").readlines():
+        f = open(versionfile_source,"r")
+        for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
                 if mo:
@@ -153,6 +154,7 @@ def get_expanded_variables(versionfile_source):
                 mo = re.search(r'=\s*"(.*)"', line)
                 if mo:
                     variables["full"] = mo.group(1)
+        f.close()
     except EnvironmentError:
         pass
     return variables
@@ -328,7 +330,8 @@ def get_expanded_variables(versionfile_source):
     # used from _version.py.
     variables = {}
     try:
-        for line in open(versionfile_source,"r").readlines():
+        f = open(versionfile_source,"r")
+        for line in f.readlines():
             if line.strip().startswith("git_refnames ="):
                 mo = re.search(r'=\s*"(.*)"', line)
                 if mo:
@@ -337,6 +340,7 @@ def get_expanded_variables(versionfile_source):
                 mo = re.search(r'=\s*"(.*)"', line)
                 if mo:
                     variables["full"] = mo.group(1)
+        f.close()
     except EnvironmentError:
         pass
     return variables
@@ -513,6 +517,7 @@ def versions_from_file(filename):
         mo = re.match("version_full = '([^']+)'", line)
         if mo:
             versions["full"] = mo.group(1)
+    f.close()
     return versions
 
 def write_to_version_file(filename, versions):


### PR DESCRIPTION
This isn't an exhaustive list, nor is it necessarily safe against
exceptions, but it does suffice for me in "normal operations."

Adding exception safe versions would be quite tiresome, as Python 2.4
does not have a try-except-finally block (only try-except and try-finally).
The code, if were to go down that road, would be:

```
f = open(...)
try:
    try:
        # use f here
    except:
        # handle exceptions
finally:
    f.close()
```
