### PR TITLE
PEP-0440 compatibility: add git-describe's commit-distance as post-release/dev-release info

### DIFF
--- a/src/git/middle.py
+++ b/src/git/middle.py
@@ -91,7 +91,7 @@ def versions_from_vcs(tag_prefix, versionfile_source, verbose=False):
     GIT = "git"
     if sys.platform == "win32":
         GIT = "git.cmd"
-    stdout = run_command([GIT, "describe", "--tags", "--dirty", "--always"],
+    stdout = run_command([GIT, "describe", "--tags", "--dirty", "--always", "--long"],
                          cwd=root)
     if stdout is None:
         return {}
@@ -99,12 +99,41 @@ def versions_from_vcs(tag_prefix, versionfile_source, verbose=False):
         if verbose:
             print("tag '%s' doesn't start with prefix '%s'" % (stdout, tag_prefix))
         return {}
-    tag = stdout[len(tag_prefix):]
+
+    # Pop 'dirty' state (if present)
+    git_version = stdout[len(tag_prefix):]
+    dirty = git_version.endswith('-dirty')
+    if dirty:
+        git_version = git_version[:git_version.rindex('-dirty')]
+
+    try:
+        # Pop commit short hash
+        idx = git_version.rindex('-g')
+        commit = git_version[idx+2:]
+        git_version = git_version[:idx]
+
+        # Pop commit-distance from tag, used for PEP-0440 compatibility
+        idx = git_version.rindex('-')
+        if re.match('^\d+$', git_version[idx+1:]):
+            distance = int(git_version[idx+1:])
+            git_version = git_version[:idx]
+
+        # All remaining information is the tag's name itself
+        tag = git_version
+
+        # Version = tag + optionally added postrelease info
+        version = tag
+        if distance:
+            version += '.post0.dev%u' % (distance,)
+    except ValueError:
+        commit = git_version
+        version = '0.dev0'
+
     stdout = run_command([GIT, "rev-parse", "HEAD"], cwd=root)
     if stdout is None:
         return {}
     full = stdout.strip()
-    if tag.endswith("-dirty"):
+    if dirty:
         full += "-dirty"
-    return {"version": tag, "full": full}
+    return {"version": version, "full": full}
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -225,7 +225,7 @@ def versions_from_vcs(tag_prefix, versionfile_source, verbose=False):
     GIT = "git"
     if sys.platform == "win32":
         GIT = "git.cmd"
-    stdout = run_command([GIT, "describe", "--tags", "--dirty", "--always"],
+    stdout = run_command([GIT, "describe", "--tags", "--dirty", "--always", "--long"],
                          cwd=root)
     if stdout is None:
         return {}
@@ -233,14 +233,43 @@ def versions_from_vcs(tag_prefix, versionfile_source, verbose=False):
         if verbose:
             print("tag '%%s' doesn't start with prefix '%%s'" %% (stdout, tag_prefix))
         return {}
-    tag = stdout[len(tag_prefix):]
+
+    # Pop 'dirty' state (if present)
+    git_version = stdout[len(tag_prefix):]
+    dirty = git_version.endswith('-dirty')
+    if dirty:
+        git_version = git_version[:git_version.rindex('-dirty')]
+
+    try:
+        # Pop commit short hash
+        idx = git_version.rindex('-g')
+        commit = git_version[idx+2:]
+        git_version = git_version[:idx]
+
+        # Pop commit-distance from tag, used for PEP-0440 compatibility
+        idx = git_version.rindex('-')
+        if re.match('^\d+$', git_version[idx+1:]):
+            distance = int(git_version[idx+1:])
+            git_version = git_version[:idx]
+
+        # All remaining information is the tag's name itself
+        tag = git_version
+
+        # Version = tag + optionally added postrelease info
+        version = tag
+        if distance:
+            version += '.post0.dev%%u' %% (distance,)
+    except ValueError:
+        commit = git_version
+        version = '0.dev0'
+
     stdout = run_command([GIT, "rev-parse", "HEAD"], cwd=root)
     if stdout is None:
         return {}
     full = stdout.strip()
-    if tag.endswith("-dirty"):
+    if dirty:
         full += "-dirty"
-    return {"version": tag, "full": full}
+    return {"version": version, "full": full}
 
 
 def versions_from_parentdir(parentdir_prefix, versionfile_source, verbose=False):
@@ -409,7 +438,7 @@ def versions_from_vcs(tag_prefix, versionfile_source, verbose=False):
     GIT = "git"
     if sys.platform == "win32":
         GIT = "git.cmd"
-    stdout = run_command([GIT, "describe", "--tags", "--dirty", "--always"],
+    stdout = run_command([GIT, "describe", "--tags", "--dirty", "--always", "--long"],
                          cwd=root)
     if stdout is None:
         return {}
@@ -417,14 +446,43 @@ def versions_from_vcs(tag_prefix, versionfile_source, verbose=False):
         if verbose:
             print("tag '%s' doesn't start with prefix '%s'" % (stdout, tag_prefix))
         return {}
-    tag = stdout[len(tag_prefix):]
+
+    # Pop 'dirty' state (if present)
+    git_version = stdout[len(tag_prefix):]
+    dirty = git_version.endswith('-dirty')
+    if dirty:
+        git_version = git_version[:git_version.rindex('-dirty')]
+
+    try:
+        # Pop commit short hash
+        idx = git_version.rindex('-g')
+        commit = git_version[idx+2:]
+        git_version = git_version[:idx]
+
+        # Pop commit-distance from tag, used for PEP-0440 compatibility
+        idx = git_version.rindex('-')
+        if re.match('^\d+$', git_version[idx+1:]):
+            distance = int(git_version[idx+1:])
+            git_version = git_version[:idx]
+
+        # All remaining information is the tag's name itself
+        tag = git_version
+
+        # Version = tag + optionally added postrelease info
+        version = tag
+        if distance:
+            version += '.post0.dev%u' % (distance,)
+    except ValueError:
+        commit = git_version
+        version = '0.dev0'
+
     stdout = run_command([GIT, "rev-parse", "HEAD"], cwd=root)
     if stdout is None:
         return {}
     full = stdout.strip()
-    if tag.endswith("-dirty"):
+    if dirty:
         full += "-dirty"
-    return {"version": tag, "full": full}
+    return {"version": version, "full": full}
 
 
 def versions_from_parentdir(parentdir_prefix, versionfile_source, verbose=False):


### PR DESCRIPTION
PEP-0440 compatibility: add git-describe's commit-distance as post-release/dev-release info

This automatically creates post-release, development releases for the tag found *and* ensures they're PEP-0440 compatible to ensure tools like `pip` can work with them.