### PR TITLE
Support builds using cx_Freeze to generate executables

### DIFF
--- a/src/header.py
+++ b/src/header.py
@@ -10,12 +10,6 @@ from distutils.core import Command
 from distutils.command.sdist import sdist as _sdist
 from distutils.command.build import build as _build
 
-# Compatibility with cx_Freeze
-try:
-  from cx_Freeze.dist import build_exe as _build_exe
-except ImportError:
-  pass
-
 versionfile_source = None
 versionfile_build = None
 tag_prefix = None

--- a/src/trailer.py
+++ b/src/trailer.py
@@ -113,24 +113,27 @@ class cmd_build(_build):
         f.write(SHORT_VERSION_PY % versions)
         f.close()
 
-class cmd_build_exe(_build_exe):
-    def run(self):
-        versions = get_versions(verbose=True)
-        target_versionfile = versionfile_source
-        print("UPDATING %s" % target_versionfile)
-        os.unlink(target_versionfile)
-        f = open(target_versionfile, "w")
-        f.write(SHORT_VERSION_PY % versions)
-        f.close()
-        _build_exe.run(self)
-        os.unlink(target_versionfile)
-        f = open(versionfile_source, "w")
-        f.write(LONG_VERSION_PY % {"DOLLAR": "$",
-                                   "TAG_PREFIX": tag_prefix,
-                                   "PARENTDIR_PREFIX": parentdir_prefix,
-                                   "VERSIONFILE_SOURCE": versionfile_source,
-                                   })
-        f.close()
+if 'cx_Freeze' in sys.modules:  # cx_freeze enabled?
+  from cx_Freeze.dist import build_exe as _build_exe
+
+  class cmd_build_exe(_build_exe):
+      def run(self):
+          versions = get_versions(verbose=True)
+          target_versionfile = versionfile_source
+          print("UPDATING %s" % target_versionfile)
+          os.unlink(target_versionfile)
+          f = open(target_versionfile, "w")
+          f.write(SHORT_VERSION_PY % versions)
+          f.close()
+          _build_exe.run(self)
+          os.unlink(target_versionfile)
+          f = open(versionfile_source, "w")
+          f.write(LONG_VERSION_PY % {"DOLLAR": "$",
+                                     "TAG_PREFIX": tag_prefix,
+                                     "PARENTDIR_PREFIX": parentdir_prefix,
+                                     "VERSIONFILE_SOURCE": versionfile_source,
+                                     })
+          f.close()
 
 class cmd_sdist(_sdist):
     def run(self):


### PR DESCRIPTION
If the project's setup.py uses cx_Freeze to build the project, it executes a 'build_exe' task that needs to be hooked into, and the 'build' step must be unhooked.
