### PR TITLE
added pep440 compliance option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The Versioneer
 * Brian Warner
 * License: Public Domain
 * Compatible With: python2.6, 2.7, 3.2, 3.3, 3.4, and pypy
-
-[![Build Status](https://travis-ci.org/warner/python-versioneer.png?branch=master)](https://travis-ci.org/warner/python-versioneer)
+* [![Latest Version](https://pypip.in/version/versioneer/badge.svg)](https://pypi.python.org/pypi/versioneer/)
+* [![Build Status](https://travis-ci.org/warner/python-versioneer.png?branch=master)](https://travis-ci.org/warner/python-versioneer)
 
 This is a tool for managing a recorded version number in distutils-based
 python projects. The goal is to remove the tedious and error-prone "update

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Versioneer
 * Brian Warner
 * License: Public Domain
 * Compatible With: python2.6, 2.7, 3.2, 3.3, 3.4, and pypy
-* [![Latest Version](https://pypip.in/version/versioneer/badge.svg)](https://pypi.python.org/pypi/versioneer/)
+* [![Latest Version](https://pypip.in/version/versioneer/badge.svg?style=flat)](https://pypi.python.org/pypi/versioneer/)
 * [![Build Status](https://travis-ci.org/warner/python-versioneer.png?branch=master)](https://travis-ci.org/warner/python-versioneer)
 
 This is a tool for managing a recorded version number in distutils-based

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ version-control system about the current tree.
 """
 
 # as nice as it'd be to versioneer ourselves, that sounds messy.
-VERSION = "0.12+"
+VERSION = "0.13"
 
 
 def ver(s):

--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -36,27 +36,52 @@ def get_versions(default=DEFAULT, verbose=False):
         ver = versions_from_keywords_f(vcs_keywords, tag_prefix)
         if ver:
             if verbose: print("got version from expanded keyword %s" % ver)
-            return ver
+            if not pep440_compliant:
+                return ver
+            else:
+                return rep_by_pep440(ver)
 
     ver = versions_from_file(versionfile_abs)
     if ver:
         if verbose: print("got version from file %s %s" % (versionfile_abs,ver))
-        return ver
+        if not pep440_compliant:
+            return ver
+        else:
+            return rep_by_pep440(ver)
 
     versions_from_vcs_f = vcs_function(VCS, "versions_from_vcs")
     if versions_from_vcs_f:
         ver = versions_from_vcs_f(tag_prefix, root, verbose)
         if ver:
             if verbose: print("got version from VCS %s" % ver)
-            return ver
+            if not pep440_compliant:
+                return ver
+            else:
+                return rep_by_pep440(ver)
 
     ver = versions_from_parentdir(parentdir_prefix, root, verbose)
     if ver:
         if verbose: print("got version from parentdir %s" % ver)
-        return ver
+        if not pep440_compliant:
+            return ver
+        else:
+            return rep_by_pep440(ver)
 
     if verbose: print("got version from default %s" % default)
     return default
 
 def get_version(verbose=False):
     return get_versions(verbose=verbose)["version"]
+
+
+def git2pep440(ver_str):
+    try:
+        tag, commits, _ = ver_str.split('-', 2)
+        return "{}.{}{}".format(tag, release_type_string, commits)
+    except ValueError:
+        return ver_str
+
+
+def rep_by_pep440(ver):
+    ver["version"] = git2pep440(ver["version"])
+    return ver

--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -76,8 +76,11 @@ def get_version(verbose=False):
 
 def git2pep440(ver_str):
     try:
-        tag, commits, _ = ver_str.split('-', 2)
-        return "{}.{}{}".format(tag, release_type_string, commits)
+        tag, commits, local = ver_str.split('-', 2)
+        if local_version:
+            return "{}.{}{}+{}".format(tag, release_type_string, commits, local)
+        else:
+            return "{}.{}{}".format(tag, release_type_string, commits)
     except ValueError:
         return ver_str
 

--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -11,7 +11,7 @@ def get_versions(default={"version": "unknown", "full": ""}, verbose=False):
         return ver
 
     try:
-        root = os.path.abspath(__file__)
+        root = os.path.realpath(__file__)
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.

--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -8,7 +8,7 @@ def get_versions(default={"version": "unknown", "full": ""}, verbose=False):
     keywords = {"refnames": git_refnames, "full": git_full}
     ver = git_versions_from_keywords(keywords, tag_prefix, verbose)
     if ver:
-        return ver
+        return rep_by_pep440(ver)
 
     try:
         root = os.path.realpath(__file__)
@@ -20,6 +20,6 @@ def get_versions(default={"version": "unknown", "full": ""}, verbose=False):
     except NameError:
         return default
 
-    return (git_versions_from_vcs(tag_prefix, root, verbose)
+    return rep_by_pep440(git_versions_from_vcs(tag_prefix, root, verbose)
             or versions_from_parentdir(parentdir_prefix, root, verbose)
             or default)

--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -15,7 +15,7 @@ def get_versions(default={"version": "unknown", "full": ""}, verbose=False):
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in range(len(versionfile_source.split(os.sep))):
+        for i in range(len(versionfile_source.split('/'))):
             root = os.path.dirname(root)
     except NameError:
         return default

--- a/src/header.py
+++ b/src/header.py
@@ -18,7 +18,7 @@ tag_prefix = None
 parentdir_prefix = None
 VCS = None
 pep440_compliant = False
-release_type_string = "dev"
-
+release_type_string = "post.dev"
+local_version = True
 # these dictionaries contain VCS-specific tools
 LONG_VERSION_PY = {}

--- a/src/header.py
+++ b/src/header.py
@@ -17,7 +17,7 @@ versionfile_build = None
 tag_prefix = None
 parentdir_prefix = None
 VCS = None
-pep440_compliant = False
+pep440_compliant = True
 release_type_string = "post.dev"
 local_version = True
 # these dictionaries contain VCS-specific tools

--- a/src/header.py
+++ b/src/header.py
@@ -17,6 +17,8 @@ versionfile_build = None
 tag_prefix = None
 parentdir_prefix = None
 VCS = None
+pep440_compliant = False
+release_type_string = "dev"
 
 # these dictionaries contain VCS-specific tools
 LONG_VERSION_PY = {}

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -48,7 +48,7 @@ class Keywords(unittest.TestCase):
         self.assertEqual(v["version"], "full")
         self.assertEqual(v["full"], "full")
 
-VERBOSE = False
+VERBOSE = True
 
 class Repo(unittest.TestCase):
     def git(self, *args, **kwargs):
@@ -201,7 +201,7 @@ class Repo(unittest.TestCase):
         self.git("add", "setup.py")
         self.git("commit", "-m", "dirty")
         full = self.git("rev-parse", "HEAD")
-        short = "1.0-1-g%s" % full[:7]
+        short = "1.0.post.dev1+g%s" % full[:7]
         self.do_checks(short, full, dirty=False, state="SC")
 
 


### PR DESCRIPTION
Hi, we have added some functionalty to replace the version string git commit number with a more pep440 compliant 'dev'. There is also the option to replace 'dev' with a string of your choice (e.g. 'post'). This can be configured via the two new header.py variables:

    pep440_compliant (default False)
    release_type_string (default 'dev')

We can see there is some major refactoring in progress in the 'template' branch, but we hoped it would be possible to incorporate these small updates to the master. No test for 'git2pep440', but can be added if you agree to incorporate the changes.