### PR TITLE
FIX: Use / instead of os.sep

### DIFF
--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -15,7 +15,7 @@ def get_versions(default={"version": "unknown", "full": ""}, verbose=False):
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in range(len(versionfile_source.split(os.sep))):
+        for i in range(len(versionfile_source.split('/'))):
             root = os.path.dirname(root)
     except NameError:
         return default


### PR DESCRIPTION
In `_version.get_versions()` the root directory is determined by splitting `versionfile_source`. According to the documentation this is something like `package/_version.py`, i.e. separated by slashes. Since `os.sep` is used in `get_versions()` this string will be splitted by a backslash which is wrong. Since most Python packages should work on Windows and Linux, the versioneer configuration should follow the slash convention to separate directories and files.