### PR TITLE
[Readme] changed import statement to support multiple dependant setuptools projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,13 @@ To versioneer-enable your project:
 * 2: add the following lines to the top of your `setup.py`, with the
   configuration values you decided earlier:
 
-        import versioneer
+        import imp
+        fp, pathname, description = imp.find_module('versioneer')
+        try:
+            versioneer = imp.load_module('versioneer', fp, pathname, description)
+        finally:
+            if fp: fp.close()
+        
         versioneer.VCS = 'git'
         versioneer.versionfile_source = 'src/myproject/_version.py'
         versioneer.versionfile_build = 'myproject/_version.py'


### PR DESCRIPTION
Fix for #52. I've tested this with 2 setuptools projects A, B, where A depends B and both use versioneer.