### PR TITLE
Add support for locating setup.py below the git repo root

### DIFF
--- a/src/from_parentdir.py
+++ b/src/from_parentdir.py
@@ -1,11 +1,18 @@
 
 def versions_from_parentdir(parentdir_prefix, root, verbose=False):
     # Source tarballs conventionally unpack into a directory that includes
-    # both the project name and a version string.
-    dirname = os.path.basename(root)
-    if not dirname.startswith(parentdir_prefix):
-        if verbose:
-            print("guessing rootdir is '%s', but '%s' doesn't start with prefix '%s'" %
-                  (root, dirname, parentdir_prefix))
-        return None
-    return {"version": dirname[len(parentdir_prefix):], "full": ""}
+    # both the project name and a version string. We will also support searching
+    # up two directory levels for an appropriately named parent directory
+    rootdirs = []
+
+    for i in range(3):
+        dirname = os.path.basename(root)
+        if dirname.startswith(parentdir_prefix):
+            return {"version": dirname[len(parentdir_prefix):], "full": ""}
+        else:
+            rootdirs.append(root)
+            root = os.path.dirname(root) # up a level
+    if verbose:
+        print("Tried directories %s but none started with prefix %s" %
+            (str(rootdirs), parentdir_prefix) )
+    return None

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -4,15 +4,16 @@ def git_versions_from_vcs(tag_prefix, root, verbose=False):
     # if the git-archive 'subst' keywords were *not* expanded, and
     # _version.py hasn't already been rewritten with a short version string,
     # meaning we're inside a checked out source tree.
-
-    if not os.path.exists(os.path.join(root, ".git")):
-        if verbose:
-            print("no .git in %s" % root)
-        return {}
-
     GITS = ["git"]
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
+
+    retcode = run_command_for_return_code(GITS, ["rev-parse", "--git-dir"], cwd=root)
+    if retcode == 128:
+        if verbose:
+            print("Directory %s not under git control" % root)
+        return {}
+
     stdout = run_command(GITS, ["describe", "--tags", "--dirty", "--always"],
                          cwd=root)
     if stdout is None:

--- a/src/subprocess_helper.py
+++ b/src/subprocess_helper.py
@@ -1,5 +1,32 @@
 import sys, subprocess, errno # --STRIP DURING BUILD
 
+def run_command_for_return_code(commands, args, cwd=None, verbose=False, hide_stderr=True):
+    assert isinstance(commands, list)
+    p = None
+    for c in commands:
+        try:
+            # remember shell=False, so use git.cmd on windows, not just git
+            p = subprocess.Popen([c] + args, cwd=cwd, stdout=subprocess.PIPE,
+                                 stderr=(subprocess.PIPE if hide_stderr
+                                         else None))
+            break
+        except EnvironmentError:
+            e = sys.exc_info()[1]
+            if e.errno == errno.ENOENT:
+                continue
+            if verbose:
+                print("unable to run %s" % args[0])
+                print(e)
+            return None
+    else:
+        if verbose:
+            print("unable to find command, tried %s" % (commands,))
+        return None
+    stdout = p.communicate()[0].strip()
+    if sys.version >= '3':
+        stdout = stdout.decode()
+    return p.returncode
+
 def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False):
     assert isinstance(commands, list)
     p = None

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -56,14 +56,14 @@ class Repo(unittest.TestCase):
         assert not kwargs, kwargs.keys()
         output = run_command(GITS, list(args), workdir, True)
         if output is None:
-            self.fail("problem running git")
+            self.fail("problem running git (workdir: %s)" % workdir)
         return output
     def python(self, *args, **kwargs):
         workdir = kwargs.pop("workdir", self.projpath())
         assert not kwargs, kwargs.keys()
         output = run_command([sys.executable], list(args), workdir, True)
         if output is None:
-            self.fail("problem running python")
+            self.fail("problem running python (workdir: %s)" % workdir)
         return output
     def subpath(self, path, base_dir = ""):
         return os.path.join(self.testdir, base_dir, path)
@@ -124,17 +124,7 @@ class Repo(unittest.TestCase):
         self.projdir = "project" if sub_dir else ""
         self.gitdir = "demoapp"
 
-        # create an unrelated git tree above the testdir. Some tests will run
-        # from this directory, and they should use the demoapp git
-        # environment instead of the deceptive parent
         os.mkdir(self.testdir)
-        self.git("init", workdir=self.testdir)
-        f = open(os.path.join(self.testdir, "false-repo"), "w")
-        f.write("don't look at me\n")
-        f.close()
-        self.git("add", "false-repo", workdir=self.testdir)
-        self.git("commit", "-m", "first false commit", workdir=self.testdir)
-        self.git("tag", "demo-4.0", workdir=self.testdir)
 
         shutil.copytree(demoapp_dir, self.projpath())
         setup_py_fn = os.path.join(self.projpath(), "setup.py")
@@ -220,7 +210,7 @@ class Repo(unittest.TestCase):
         self.do_checks("1.0-dirty", full+"-dirty", dirty=True, state="SB")
 
         # SC: now we make one commit past the tag
-        self.git("add", "setup.py")
+        self.git("add", "setup.py", workdir=self.projpath())
         self.git("commit", "-m", "dirty")
         full = self.git("rev-parse", "HEAD")
         short = "1.0-1-g%s" % full[:7]
@@ -263,7 +253,7 @@ class Repo(unittest.TestCase):
             # the short version to be like 1.0-1-gHEXID. The code falls back
             # to short=long
             exp_short_TD = exp_long
-        self.check_version(target, exp_short_TD, exp_long, False, state, tree="TD")
+        self.check_version(self.projpath(target), exp_short_TD, exp_long, False, state, tree="TD")
 
         # TE: unpacked setup.py sdist tarball
         dist_path = os.path.join(self.projpath(), "dist")


### PR DESCRIPTION
This addresses issue #38. 

versioneer is the best way that I've come across to manage automated versioning of python projects. I know it isn't the standard practice, but I do have a case where I have a python module that is part of a larger project that lives within a single repo, and I wanted to be able to use versioneer for this as well. 

This does a few things: 
1) Adds a test case where the git repo is created in `demoapp`, but the setup.py and other files are created in `demoapp/project`
2) In git_versions_from_vcs(), it uses git command return to test for a git directory, rather than looking for a `.git` directory
3) In versions_from_parentdir(), it will search up two levels of directory hierarchy trying to find a directory name that matches the configured prefix. 