### PR TITLE
PEP440 compliant versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,17 +197,19 @@ import the top-level `versioneer.py` and run `get_versions()`.
 Both functions return a dictionary with different keys for different flavors
 of the version string:
 
-* `['version']`: condensed tag+distance+shortid+dirty identifier. For git,
-  this uses the output of `git describe --tags --dirty --always` but strips
-  the tag_prefix. For example "0.11-2-g1076c97-dirty" indicates that the tree
-  is like the "1076c97" commit but has uncommitted changes ("-dirty"), and
-  that this commit is two revisions ("-2-") beyond the "0.11" tag. For
-  released software (exactly equal to a known tag), the identifier will only
-  contain the stripped tag, e.g. "0.11".
+* `['version']`: A condensed PEP440-compliant string, equal to the
+  un-prefixed tag name for actual releases, and containing an additional
+  "local version" section with more detail for in-between builds. For Git,
+  this is TAG[+DISTANCE.gHEX[.dirty]] , using information from `git describe
+  --tags --dirty --always`. For example "0.11+2.g1076c97.dirty" indicates
+  that the tree is like the "1076c97" commit but has uncommitted changes
+  (".dirty"), and that this commit is two revisions ("+2") beyond the "0.11"
+  tag. For released software (exactly equal to a known tag), the identifier
+  will only contain the stripped tag, e.g. "0.11".
 
 * `['full']`: detailed revision identifier. For Git, this is the full SHA1
-  commit id, followed by "-dirty" if the tree contains uncommitted changes,
-  e.g. "1076c978a8d3cfc70f408fe5974aa6c092c949ac-dirty".
+  commit id, followed by ".dirty" if the tree contains uncommitted changes,
+  e.g. "1076c978a8d3cfc70f408fe5974aa6c092c949ac.dirty".
 
 Some variants are more useful than others. Including `full` in a bug report
 should allow developers to reconstruct the exact code being tested (or
@@ -215,13 +217,6 @@ indicate the presence of local changes that should be shared with the
 developers). `version` is suitable for display in an "about" box or a CLI
 `--version` output: it can be easily compared against release notes and lists
 of bugs fixed in various releases.
-
-In the future, this will also include a
-[PEP-0440](http://legacy.python.org/dev/peps/pep-0440/) -compatible flavor
-(e.g. `1.2.post0.dev123`). This loses a lot of information (and has no room
-for a hash-based revision id), but is safe to use in a `setup.py`
-"`version=`" argument. It also enables tools like *pip* to compare version
-strings and evaluate compatibility constraint declarations.
 
 The `setup.py versioneer` command adds the following text to your
 `__init__.py` to place a basic version in `YOURPROJECT.__version__`:

--- a/src/from_file.py
+++ b/src/from_file.py
@@ -12,7 +12,7 @@ def get_versions(default={}, verbose=False):
 
 """
 
-DEFAULT = {"version": "unknown", "full": "unknown"}
+DEFAULT = {"version": "0+unknown", "full": "unknown"}
 
 
 def versions_from_file(filename):

--- a/src/git/from_keywords.py
+++ b/src/git/from_keywords.py
@@ -58,9 +58,9 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose=False):
                 print("picking %s" % r)
             return {"version": r,
                     "full": keywords["full"].strip()}
-    # no suitable tags, so version is "unknown", but full hex is still there
+    # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "unknown",
+    return {"version": "0+unknown",
             "full": keywords["full"].strip()}
 

--- a/src/git/from_keywords.py
+++ b/src/git/from_keywords.py
@@ -58,9 +58,9 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose=False):
                 print("picking %s" % r)
             return {"version": r,
                     "full": keywords["full"].strip()}
-    # no suitable tags, so we use the full revision id
+    # no suitable tags, so version is "unknown", but full hex is still there
     if verbose:
-        print("no suitable tags, using full revision id")
-    return {"version": keywords["full"].strip(),
+        print("no suitable tags, using unknown + full revision id")
+    return {"version": "unknown",
             "full": keywords["full"].strip()}
 

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -1,44 +1,50 @@
-def git_parse_vcs_describe(git_describe, tag_prefix, verbose=False):
-    if not git_describe.startswith(tag_prefix):
-        if verbose:
-            fmt = "tag '%s' doesn't start with prefix '%s'"
-            print(fmt % (git_describe, tag_prefix))
-        dirty = bool(git_describe.endswith("-dirty")) # still there
-        return None, dirty
-    git_version = git_describe[len(tag_prefix):]
+import re # --STRIP DURING BUILD
 
-    # parse TAG-NUM-gHEX[-dirty], given that TAG might contain "-"
+def git_parse_vcs_describe(git_describe, tag_prefix, verbose=False):
+    # TAG-NUM-gHEX[-dirty] or HEX[-dirty] . TAG might have hyphens.
 
     # dirty
-    dirty = git_version.endswith("-dirty")
+    dirty = git_describe.endswith("-dirty")
     if dirty:
-        git_version = git_version[:git_version.rindex("-dirty")]
+        git_describe = git_describe[:git_describe.rindex("-dirty")]
+    dirty_suffix = ".dirty" if dirty else ""
 
-    # commit: short hex revision ID
-    idx = git_version.rindex("-g")
-    commit = git_version[idx+2:]
-    git_version = git_version[:idx]
+    # now we have TAG-NUM-gHEX or HEX
+
+    if "-" not in git_describe:  # just HEX
+        return "0+untagged.g"+git_describe+dirty_suffix, dirty
+
+    # just TAG-NUM-gHEX
+    mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+    if not mo:
+        # unparseable. Maybe git-describe is misbehaving?
+        return "0+unparseable"+dirty_suffix, dirty
+
+    # tag
+    full_tag = mo.group(1)
+    if not full_tag.startswith(tag_prefix):
+        if verbose:
+            fmt = "tag '%s' doesn't start with prefix '%s'"
+            print(fmt % (full_tag, tag_prefix))
+        return None, dirty
+    tag = full_tag[len(tag_prefix):]
 
     # distance: number of commits since tag
-    idx = git_version.rindex("-")
-    if re.match("^\d+$", git_version[idx+1:]):
-        distance = int(git_version[idx+1:])
-        git_version = git_version[:idx]
+    distance = int(mo.group(2))
 
-    # tag: stripped of tag_prefix
-    tag = git_version
+    # commit: short hex revision ID
+    commit = mo.group(3)
 
     # now build up version string, with post-release "local version
-    # identifier". Our goal: TAG[+NUM.gHEX[-dirty]] . Note that if you get a
-    # tagged build and then dirty it, you'll get TAG+0.gHEX-dirty . So you
-    # can always test version.endswith("-dirty").
+    # identifier". Our goal: TAG[+NUM.gHEX[.dirty]] . Note that if you get a
+    # tagged build and then dirty it, you'll get TAG+0.gHEX.dirty . So you
+    # can always test version.endswith(".dirty").
     version = tag
     if distance or dirty:
-        version += "+%d.g%s" % (distance, commit)
-        if dirty:
-            version += "-dirty"
+        version += "+%d.g%s" % (distance, commit) + dirty_suffix
 
     return version, dirty
+
 
 def git_versions_from_vcs(tag_prefix, root, verbose=False):
     # this runs 'git' from the root of the source tree. This only gets called
@@ -49,27 +55,28 @@ def git_versions_from_vcs(tag_prefix, root, verbose=False):
     if not os.path.exists(os.path.join(root, ".git")):
         if verbose:
             print("no .git in %s" % root)
-        return {} # get_versions() will try next method
+        return {}  # get_versions() will try next method
 
     GITS = ["git"]
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
-    # this yields TAG-NUM-gHEX[-dirty]
+    # if there is a tag, this yields TAG-NUM-gHEX[-dirty]
+    # if there are no tags, this yields HEX[-dirty] (no NUM)
     stdout = run_command(GITS, ["describe", "--tags", "--dirty",
                                 "--always", "--long"],
                          cwd=root)
     # --long was added in git-1.5.5
     if stdout is None:
-        return {} # try next method
+        return {}  # try next method
     version, dirty = git_parse_vcs_describe(stdout, tag_prefix, verbose)
 
-    # build "full", which is FULLHEX[-dirty]
+    # build "full", which is FULLHEX[.dirty]
     stdout = run_command(GITS, ["rev-parse", "HEAD"], cwd=root)
     if stdout is None:
         return {}
     full = stdout.strip()
     if dirty:
-        full += "-dirty"
+        full += ".dirty"
 
     return {"version": version, "full": full}
 

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -1,3 +1,44 @@
+def git_parse_vcs_describe(git_describe, tag_prefix, verbose=False):
+    if not git_describe.startswith(tag_prefix):
+        if verbose:
+            fmt = "tag '%s' doesn't start with prefix '%s'"
+            print(fmt % (git_describe, tag_prefix))
+        dirty = bool(git_describe.endswith("-dirty")) # still there
+        return None, dirty
+    git_version = git_describe[len(tag_prefix):]
+
+    # parse TAG-NUM-gHEX[-dirty], given that TAG might contain "-"
+
+    # dirty
+    dirty = git_version.endswith("-dirty")
+    if dirty:
+        git_version = git_version[:git_version.rindex("-dirty")]
+
+    # commit: short hex revision ID
+    idx = git_version.rindex("-g")
+    commit = git_version[idx+2:]
+    git_version = git_version[:idx]
+
+    # distance: number of commits since tag
+    idx = git_version.rindex("-")
+    if re.match("^\d+$", git_version[idx+1:]):
+        distance = int(git_version[idx+1:])
+        git_version = git_version[:idx]
+
+    # tag: stripped of tag_prefix
+    tag = git_version
+
+    # now build up version string, with post-release "local version
+    # identifier". Our goal: TAG[+NUM.gHEX[-dirty]] . Note that if you get a
+    # tagged build and then dirty it, you'll get TAG+0.gHEX-dirty . So you
+    # can always test version.endswith("-dirty").
+    version = tag
+    if distance or dirty:
+        version += "+%d.g%s" % (distance, commit)
+        if dirty:
+            version += "-dirty"
+
+    return version, dirty
 
 def git_versions_from_vcs(tag_prefix, root, verbose=False):
     # this runs 'git' from the root of the source tree. This only gets called
@@ -8,26 +49,27 @@ def git_versions_from_vcs(tag_prefix, root, verbose=False):
     if not os.path.exists(os.path.join(root, ".git")):
         if verbose:
             print("no .git in %s" % root)
-        return {}
+        return {} # get_versions() will try next method
 
     GITS = ["git"]
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
-    stdout = run_command(GITS, ["describe", "--tags", "--dirty", "--always"],
+    # this yields TAG-NUM-gHEX[-dirty]
+    stdout = run_command(GITS, ["describe", "--tags", "--dirty",
+                                "--always", "--long"],
                          cwd=root)
+    # --long was added in git-1.5.5
     if stdout is None:
-        return {}
-    if not stdout.startswith(tag_prefix):
-        if verbose:
-            fmt = "tag '%s' doesn't start with prefix '%s'"
-            print(fmt % (stdout, tag_prefix))
-        return {}
-    tag = stdout[len(tag_prefix):]
+        return {} # try next method
+    version, dirty = git_parse_vcs_describe(stdout, tag_prefix, verbose)
+
+    # build "full", which is FULLHEX[-dirty]
     stdout = run_command(GITS, ["rev-parse", "HEAD"], cwd=root)
     if stdout is None:
         return {}
     full = stdout.strip()
-    if tag.endswith("-dirty"):
+    if dirty:
         full += "-dirty"
-    return {"version": tag, "full": full}
+
+    return {"version": version, "full": full}
 

--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -1,5 +1,5 @@
 
-def get_versions(default={"version": "unknown", "full": ""}, verbose=False):
+def get_versions(default={"version": "0+unknown", "full": ""}, verbose=False):
     # I am in _version.py, which lives at ROOT/VERSIONFILE_SOURCE. If we have
     # __file__, we can work backwards from there to the root. Some
     # py2exe/bbfreeze/non-CPython implementations don't do __file__, in which


### PR DESCRIPTION
This makes `get_version()` always return a PEP440-compliant string, in one of the following forms:

* TAG
* TAG+DISTANCE.gHASH[.dirty]
* 0+unknown
* 0+untagged.gHASH[.dirty]
* 0+unparseable[.dirty]

The "+" separator uses PEP440's "local version" section to represent the non-tag portions, retaining all the information from before, but not triggering "LegacyVersion" warnings. This uses ".dirty" instead of "-dirty" because "-dirty" would trigger a warning and be normalized into ".dirty" anyways.

I don't know if this format will work for everybody. On the down side, it doesn't use the .postNN and .devNN portions, which would impact projects that intentionally distribute not-at-a-tag development versions and depend upon e.g. `pip install --pre` to distinguish between real releases and these intermediate things. I'm inclined to think that anything deserving of a .post/.dev label also deserves a tag, and that one should never push an untagged release to PyPI. But I'd like to hear more about other folks' workflows before we land this.

On the plus side, this new format contains all the useful information from the old one (distance and git commit-id hash). I was previously frustrated by the apparent tradeoff between 1: making setuptools stop complaining about PEP440-incompatibility, and 2: getting to know the git hash of the tree. This removes the tradeoff. It also seems more readable to me: in `1.2+4.g123abc.dirty`, I mentally parse the pieces as:

* "1.2+4", so that's something tagged "1.2", plus four commits on top
* "4.g123abc.dirty" is like a three-digit number in a funny non-uniform radix encoding, separated by dots.
* The first "digit" is `4`, which is just an integer, and sorts naturally (as an integer).
* The second "digit" is `g123abc`, which doesn't sort in any useful order (PEP440 sorts it alphabetically) but you only ever compare this part for equality, not orderability.
* And the last "digit" `dirty` is a boolean, either there or not, and if it's there then the tree is "newer" than a tree without `.dirty`

So I'm happy with the encoding we get when we're on a tag, or post-tag. The other three cases (`0+stuff`) are basically a last-ditch effort to produce *something* PEP440-compatible despite having very little information to go on. I think these are strictly better than a non-compliant `unknown`, but it does sort of pretend there's an implicit `0` tag on the initial commit, which might seem weird at first.

This also happens to fix #12, "no version until first tag is added". In the future I'd like to change the #12 untagged case to `0+untagged.DISTANCE.gHASH[.dirty]`, or maybe just `0+DISTANCE.gHASH[.dirty]`, where DISTANCE is the total number of commits in the repo at that point. But this patch doesn't include that, since it'll involve more code (a call to `git log` to count the patches when `git describe` fails to tell us).

[PEP440](https://www.python.org/dev/peps/pep-0440/#local-version-identifiers) describes how these "local version identifiers" are supposed to be used. They're mainly for things like Debian downstream patches, so if upstream releases `1.2`, downstream might use `1.2+debian1` to indicate they've made one set of local changes. So in one sense, we're abusing this feature to add information that doesn't fit in the other part (which PEP440 calls the "public version identifier"). But in another sense, tagged sources are "upstream", and your development tree (e.g. basically any source that isn't tagged) is a "downstream". This approach gives us public version identifiers (with no "+") for anything that's tagged, which is basically the only thing you should be pushing to PyPI or referencing as a dependency from elsewhere. But if you do build something with untagged commits, you've still got a correctly-sorting traceable identifier (*with* the "+" and gHASH and `.dirty`) that should appear in all the right places.

I'm hoping that everyone who's contributed or requested PEP440 compliance changes could take a look at this and tell me if it would work for them. /cc @muggenhor @sebastianneubauer @glennmatthews @marscher @tacaswell @dairiki @matthew-brett

I'm especially interested in folks thoughts about whether `TAG[.post0.devDISTANCE]` would be better in some cases. When the "template" branch gets done, it should be easy to switch to this other form, but for now if we land this PR, you'll be getting `TAG[+DISTANCE.gHASH[.dirty]]` -style versions. (fortunately it's a one-line edit to get the other form, and everybody has to manually upgrade their versioneer installation anyways, so nothing will immediately break when we make the next release, and it should be easy for folks who need .post.dev -style to get it).
