### PR TITLE
use setup.cfg (instead of setup.py), and remove "setup.py versioneer" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,16 +139,16 @@ To versioneer-enable your project:
 * 1: Run `versioneer-installer` to copy `versioneer.py` into the top of your
   source tree.
 
-* 2: add the following lines to the top of your `setup.py`, with the
-  configuration values you decided earlier:
+* 2: modify your `setup.cfg`, adding a section named `[versioneer]` and
+  populating it with the configuration values you decided earlier:
 
   ````
-  import versioneer
-  versioneer.VCS = 'git'
-  versioneer.versionfile_source = 'src/myproject/_version.py'
-  versioneer.versionfile_build = 'myproject/_version.py'
-  versioneer.tag_prefix = '' # tags are like 1.2.0
-  versioneer.parentdir_prefix = 'myproject-' # dirname like 'myproject-1.2.0'
+  [versioneer]
+  VCS = git
+  versionfile_source = src/myproject/_version.py
+  versionfile_build = myproject/_version.py
+  tag_prefix = ""
+  parentdir_prefix = myproject-
   ````
 
 * 3: add the following arguments to the setup() call in your setup.py:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ system, and maybe making new tarballs.
 ## Quick Install
 
 * `pip install versioneer` to somewhere to your $PATH
-* run `versioneer-installer` in your source tree: this installs `versioneer.py`
-* follow the instructions below (also in the `versioneer.py` docstring)
+* add a `[versioneer]` section to your setup.cfg (see below)
+* run `versioneer-installer` in your source tree, commit the results
 
 ## Version Identifiers
 
@@ -136,10 +136,7 @@ one thing: write a copy of `versioneer.py` into the current directory.
 
 To versioneer-enable your project:
 
-* 1: Run `versioneer-installer` to copy `versioneer.py` into the top of your
-  source tree.
-
-* 2: modify your `setup.cfg`, adding a section named `[versioneer]` and
+* 1: Modify your `setup.cfg`, adding a section named `[versioneer]` and
   populating it with the configuration values you decided earlier:
 
   ````
@@ -151,19 +148,24 @@ To versioneer-enable your project:
   parentdir_prefix = myproject-
   ````
 
-* 3: add the following arguments to the setup() call in your setup.py:
+* 2: Run `versioneer-installer`. This will do the following:
+
+  * copy `versioneer.py` into the top of your source tree
+  * create `_version.py` in the right place (`versionfile_source`)
+  * modify your `__init__.py` (if one exists next to `_version.py`) to define
+    `__version__` (by calling a function from `_version.py`)
+  * modify your `MANIFEST.in` to include both `versioneer.py` and the
+    generated `_version.py` in sdist tarballs
+
+* 3: add a `import versioneer` to your setup.py, and add the following
+  arguments to the setup() call:
 
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
 
-* 4: now run `setup.py setup_versioneer`, which will create `_version.py`,
-  and will modify your `__init__.py` (if one exists next to `_version.py`) to
-  define `__version__` (by calling a function from `_version.py`). It will
-  also modify your `MANIFEST.in` to include both `versioneer.py` and the
-  generated `_version.py` in sdist tarballs.
-
-* 5: commit these changes to your VCS. To make sure you won't forget,
-  `setup.py setup_versioneer` will mark everything it touched for addition.
+* 4: commit these changes to your VCS. To make sure you won't forget,
+  `versioneer-installer` will mark everything it touched for addition using
+  `git add`.
 
 ## Post-Installation Usage
 
@@ -238,11 +240,10 @@ The `setup.py setup_versioneer` command adds the following text to your
 To upgrade your project to a new release of Versioneer, do the following:
 
 * install the new Versioneer (`pip install -U versioneer` or equivalent)
-* re-run `versioneer-installer` in your source tree to replace your copy of
-  `versioneer.py`
-* edit `setup.py`, if necessary, to include any new configuration settings
+* edit `setup.cfg`, if necessary, to include any new configuration settings
   indicated by the release notes
-* re-run `setup.py setup_versioneer` to replace `SRC/_version.py`
+* re-run `versioneer-installer` in your source tree, to replace
+  `SRC/_version.py`
 * commit any changed files
 
 ### Upgrading from 0.10 to 0.11
@@ -262,6 +263,14 @@ hyphen-separated strings like "0.11-2-g1076c97-dirty". 0.14 and beyond use a
 plus-separated "local version" section strings, with dot-separated
 components, like "0.11+2.g1076c97". PEP440-strict tools did not like the old
 format, but should be ok with the new one.
+
+## Upgrading to XXX
+
+Starting with this version, Versioneer is configured with a `[versioneer]`
+section in your `setup.cfg` file. Earlier versions required the `setup.py` to
+set attributes on the `versioneer` module immediately after import. The new
+version will refuse to run (exception during import) until you have provided
+the necessary `setup.cfg` section.
 
 ## Future Directions
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ First, decide on values for the following configuration variables:
   `__init__.py` file, so it can be imported at runtime. If your project uses
   `src/myproject/__init__.py`, this should be `src/myproject/_version.py`.
   This file should be checked in to your VCS as usual: the copy created below
-  by `setup.py versioneer` will include code that parses expanded VCS
+  by `setup.py setup_versioneer` will include code that parses expanded VCS
   keywords in generated tarballs. The 'build' and 'sdist' commands will
   replace it with a copy that has just the calculated version string.
 
@@ -99,8 +99,8 @@ First, decide on values for the following configuration variables:
   therefore never import `_version.py`), since "setup.py sdist" -based trees
   still need somewhere to record the pre-calculated version strings. Anywhere
   in the source tree should do. If there is a `__init__.py` next to your
-  `_version.py`, the `setup.py versioneer` command (described below) will
-  append some `__version__`-setting assignments, if they aren't already
+  `_version.py`, the `setup.py setup_versioneer` command (described below)
+  will append some `__version__`-setting assignments, if they aren't already
   present.
 
 * `versionfile_build`:
@@ -156,14 +156,14 @@ To versioneer-enable your project:
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
 
-* 4: now run `setup.py versioneer`, which will create `_version.py`, and will
-  modify your `__init__.py` (if one exists next to `_version.py`) to define
-  `__version__` (by calling a function from `_version.py`). It will also
-  modify your `MANIFEST.in` to include both `versioneer.py` and the generated
-  `_version.py` in sdist tarballs.
+* 4: now run `setup.py setup_versioneer`, which will create `_version.py`,
+  and will modify your `__init__.py` (if one exists next to `_version.py`) to
+  define `__version__` (by calling a function from `_version.py`). It will
+  also modify your `MANIFEST.in` to include both `versioneer.py` and the
+  generated `_version.py` in sdist tarballs.
 
 * 5: commit these changes to your VCS. To make sure you won't forget,
-  `setup.py versioneer` will mark everything it touched for addition.
+  `setup.py setup_versioneer` will mark everything it touched for addition.
 
 ## Post-Installation Usage
 
@@ -226,7 +226,7 @@ developers). `version` is suitable for display in an "about" box or a CLI
 `--version` output: it can be easily compared against release notes and lists
 of bugs fixed in various releases.
 
-The `setup.py versioneer` command adds the following text to your
+The `setup.py setup_versioneer` command adds the following text to your
 `__init__.py` to place a basic version in `YOURPROJECT.__version__`:
 
     from ._version import get_versions
@@ -242,14 +242,14 @@ To upgrade your project to a new release of Versioneer, do the following:
   `versioneer.py`
 * edit `setup.py`, if necessary, to include any new configuration settings
   indicated by the release notes
-* re-run `setup.py versioneer` to replace `SRC/_version.py`
+* re-run `setup.py setup_versioneer` to replace `SRC/_version.py`
 * commit any changed files
 
 ### Upgrading from 0.10 to 0.11
 
 You must add a `versioneer.VCS = "git"` to your `setup.py` before re-running
-`setup.py versioneer`. This will enable the use of additional version-control
-systems (SVN, etc) in the future.
+`setup.py setup_versioneer`. This will enable the use of additional
+version-control systems (SVN, etc) in the future.
 
 ### Upgrading from 0.11 to 0.12
 

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,9 @@ def generate_versioneer():
 
     s.write(get("src/from_parentdir.py", do_strip=True))
     s.write(get("src/from_file.py", add_ver=True, do_strip=True))
-    s.write(get("src/get_versions.py", add_ver=True, do_strip=True))
-    s.write(get("src/cmdclass.py", add_ver=True, do_strip=True))
+    s.write(get("src/get_versions.py", do_strip=True))
+    s.write(get("src/cmdclass.py", do_strip=True))
+    s.write(get("src/setupfunc.py", do_strip=True))
 
     return s.getvalue().encode("utf-8")
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,17 @@ def get_vcs_list():
             in os.listdir(project_path)
             if path.isdir(path.join(project_path, filename))]
 
+def generate_long_version_py(VCS):
+    s = io.StringIO()
+    s.write(get("src/%s/long_header.py" % VCS, add_ver=True, do_strip=True))
+    for piece in ["src/subprocess_helper.py",
+                  "src/from_parentdir.py",
+                  "src/%s/from_keywords.py" % VCS,
+                  "src/%s/from_vcs.py" % VCS,
+                  "src/%s/long_get_versions.py" % VCS]:
+        s.write(get(piece, unquote=True, do_strip=True))
+    return s.getvalue()
+
 def generate_versioneer():
     s = io.StringIO()
     s.write(get("src/header.py", add_ver=True, do_readme=True))
@@ -60,14 +71,7 @@ def generate_versioneer():
 
     for VCS in get_vcs_list():
         s.write(u("LONG_VERSION_PY['%s'] = '''\n" % VCS))
-        s.write(get("src/%s/long_header.py" % VCS, add_ver=True, do_strip=True))
-        s.write(get("src/subprocess_helper.py", unquote=True, do_strip=True))
-        s.write(get("src/from_parentdir.py", unquote=True, do_strip=True))
-        s.write(get("src/%s/from_keywords.py" % VCS,
-                    unquote=True, do_strip=True))
-        s.write(get("src/%s/from_vcs.py" % VCS, unquote=True, do_strip=True))
-        s.write(get("src/%s/long_get_versions.py" % VCS,
-                    unquote=True, do_strip=True))
+        s.write(generate_long_version_py(VCS))
         s.write(u("'''\n"))
 
         s.write(get("src/%s/from_keywords.py" % VCS, do_strip=True))
@@ -106,9 +110,9 @@ class make_long_version_py_git(Command):
         pass
     def run(self):
         assert os.path.exists("versioneer.py")
-        from versioneer import LONG_VERSION_PY
+        long_version = generate_long_version_py("git")
         with open("git_version.py", "w") as f:
-            f.write(LONG_VERSION_PY["git"] %
+            f.write(long_version %
                     {"DOLLAR": "$",
                      "TAG_PREFIX": "tag-",
                      "PARENTDIR_PREFIX": "parentdir_prefix",

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -12,19 +12,20 @@ class cmd_version(Command):
         pass
 
     def run(self):
-        ver = get_version(verbose=True)
+        ver = get_version()
         print("Version is currently: %s" % ver)
 
 
 class cmd_build(_build):
     def run(self):
-        versions = get_versions(verbose=True)
+        cfg = get_config()
+        versions = get_versions()
         _build.run(self)
         # now locate _version.py in the new build/ directory and replace it
         # with an updated value
-        if versionfile_build:
+        if cfg.versionfile_build:
             target_versionfile = os.path.join(self.build_lib,
-                                              versionfile_build)
+                                              cfg.versionfile_build)
             print("UPDATING %s" % target_versionfile)
             write_to_version_file(target_versionfile, versions)
 
@@ -33,36 +34,38 @@ if 'cx_Freeze' in sys.modules:  # cx_freeze enabled?
 
     class cmd_build_exe(_build_exe):
         def run(self):
-            versions = get_versions(verbose=True)
-            target_versionfile = versionfile_source
+            cfg = get_config()
+            versions = get_versions()
+            target_versionfile = cfg.versionfile_source
             print("UPDATING %s" % target_versionfile)
             write_to_version_file(target_versionfile, versions)
 
             _build_exe.run(self)
             os.unlink(target_versionfile)
-            with open(versionfile_source, "w") as f:
-                assert VCS is not None, "please set versioneer.VCS"
-                LONG = LONG_VERSION_PY[VCS]
+            with open(cfg.versionfile_source, "w") as f:
+                assert cfg.VCS is not None, "please set versioneer.VCS"
+                LONG = LONG_VERSION_PY[cfg.VCS]
                 f.write(LONG % {"DOLLAR": "$",
-                                "TAG_PREFIX": tag_prefix,
-                                "PARENTDIR_PREFIX": parentdir_prefix,
-                                "VERSIONFILE_SOURCE": versionfile_source,
+                                "TAG_PREFIX": cfg.tag_prefix,
+                                "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                                "VERSIONFILE_SOURCE": cfg.versionfile_source,
                                 })
 
 
 class cmd_sdist(_sdist):
     def run(self):
-        versions = get_versions(verbose=True)
+        versions = get_versions()
         self._versioneer_generated_versions = versions
         # unless we update this, the command will keep using the old version
         self.distribution.metadata.version = versions["version"]
         return _sdist.run(self)
 
     def make_release_tree(self, base_dir, files):
+        cfg = get_config()
         _sdist.make_release_tree(self, base_dir, files)
         # now locate _version.py in the new base_dir directory (remembering
         # that it may be a hardlink) and replace it with an updated value
-        target_versionfile = os.path.join(base_dir, versionfile_source)
+        target_versionfile = os.path.join(base_dir, cfg.versionfile_source)
         print("UPDATING %s" % target_versionfile)
         write_to_version_file(target_versionfile,
                               self._versioneer_generated_versions)

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -1,3 +1,12 @@
+import os, sys # --STRIP DURING BUILD
+from distutils.command.build import build as _build # --STRIP DURING BUILD
+from distutils.command.sdist import sdist as _sdist # --STRIP DURING BUILD
+from distutils.core import Command # --STRIP DURING BUILD
+LONG_VERSION_PY = {} # --STRIP DURING BUILD
+def get_version(): pass # --STRIP DURING BUILD
+def get_versions(): pass # --STRIP DURING BUILD
+def get_config(): pass # --STRIP DURING BUILD
+def write_to_version_file(): pass # --STRIP DURING BUILD
 
 
 class cmd_version(Command):

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -67,94 +67,9 @@ class cmd_sdist(_sdist):
         write_to_version_file(target_versionfile,
                               self._versioneer_generated_versions)
 
-INIT_PY_SNIPPET = """
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
-"""
-
-
-class cmd_update_files(Command):
-    description = ("install/upgrade Versioneer files: "
-                   "__init__.py SRC/_version.py")
-    user_options = []
-    boolean_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        print(" creating %s" % versionfile_source)
-        with open(versionfile_source, "w") as f:
-            assert VCS is not None, "please set versioneer.VCS"
-            LONG = LONG_VERSION_PY[VCS]
-            f.write(LONG % {"DOLLAR": "$",
-                            "TAG_PREFIX": tag_prefix,
-                            "PARENTDIR_PREFIX": parentdir_prefix,
-                            "VERSIONFILE_SOURCE": versionfile_source,
-                            })
-
-        ipy = os.path.join(os.path.dirname(versionfile_source), "__init__.py")
-        if os.path.exists(ipy):
-            try:
-                with open(ipy, "r") as f:
-                    old = f.read()
-            except EnvironmentError:
-                old = ""
-            if INIT_PY_SNIPPET not in old:
-                print(" appending to %s" % ipy)
-                with open(ipy, "a") as f:
-                    f.write(INIT_PY_SNIPPET)
-            else:
-                print(" %s unmodified" % ipy)
-        else:
-            print(" %s doesn't exist, ok" % ipy)
-            ipy = None
-
-        # Make sure both the top-level "versioneer.py" and versionfile_source
-        # (PKG/_version.py, used by runtime code) are in MANIFEST.in, so
-        # they'll be copied into source distributions. Pip won't be able to
-        # install the package without this.
-        manifest_in = os.path.join(get_root(), "MANIFEST.in")
-        simple_includes = set()
-        try:
-            with open(manifest_in, "r") as f:
-                for line in f:
-                    if line.startswith("include "):
-                        for include in line.split()[1:]:
-                            simple_includes.add(include)
-        except EnvironmentError:
-            pass
-        # That doesn't cover everything MANIFEST.in can do
-        # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
-        # it might give some false negatives. Appending redundant 'include'
-        # lines is safe, though.
-        if "versioneer.py" not in simple_includes:
-            print(" appending 'versioneer.py' to MANIFEST.in")
-            with open(manifest_in, "a") as f:
-                f.write("include versioneer.py\n")
-        else:
-            print(" 'versioneer.py' already in MANIFEST.in")
-        if versionfile_source not in simple_includes:
-            print(" appending versionfile_source ('%s') to MANIFEST.in" %
-                  versionfile_source)
-            with open(manifest_in, "a") as f:
-                f.write("include %s\n" % versionfile_source)
-        else:
-            print(" versionfile_source already in MANIFEST.in")
-
-        # Make VCS-specific changes. For git, this means creating/changing
-        # .gitattributes to mark _version.py for export-time keyword
-        # substitution.
-        do_vcs_install(manifest_in, versionfile_source, ipy)
-
 
 def get_cmdclass():
     cmds = {'version': cmd_version,
-            'setup_versioneer': cmd_update_files,
             'build': cmd_build,
             'sdist': cmd_sdist,
             }

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -154,7 +154,7 @@ class cmd_update_files(Command):
 
 def get_cmdclass():
     cmds = {'version': cmd_version,
-            'versioneer': cmd_update_files,
+            'setup_versioneer': cmd_update_files,
             'build': cmd_build,
             'sdist': cmd_sdist,
             }

--- a/src/from_parentdir.py
+++ b/src/from_parentdir.py
@@ -1,5 +1,6 @@
 import os # --STRIP DURING BUILD
 
+
 def versions_from_parentdir(parentdir_prefix, root, verbose):
     # Source tarballs conventionally unpack into a directory that includes
     # both the project name and a version string.

--- a/src/from_parentdir.py
+++ b/src/from_parentdir.py
@@ -1,6 +1,6 @@
+import os # --STRIP DURING BUILD
 
-
-def versions_from_parentdir(parentdir_prefix, root, verbose=False):
+def versions_from_parentdir(parentdir_prefix, root, verbose):
     # Source tarballs conventionally unpack into a directory that includes
     # both the project name and a version string.
     dirname = os.path.basename(root)

--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -10,14 +10,15 @@ def vcs_function(vcs, suffix):
     return getattr(sys.modules[__name__], '%s_%s' % (vcs, suffix), None)
 
 
-def get_versions(verbose=False):
-    # returns dict with two keys: 'version' and 'full'
-    assert versionfile_source is not None, \
-        "please set versioneer.versionfile_source"
-    assert tag_prefix is not None, "please set versioneer.tag_prefix"
-    assert parentdir_prefix is not None, \
-        "please set versioneer.parentdir_prefix"
-    assert VCS is not None, "please set versioneer.VCS"
+def get_versions():
+    config = get_config()
+    assert config.versionfile_source is not None, \
+        "please set [versioneer] versionfile_source="
+    assert config.tag_prefix is not None, "please set [versioneer] tag_prefix="
+    assert config.parentdir_prefix is not None, \
+        "please set [versioneer] parentdir_prefix="
+    assert config.VCS is not None, "please set [versioneer] VCS="
+    verbose = config.verbose
 
     # I am in versioneer.py, which must live at the top of the source tree,
     # which we use to compute the root directory. py2exe/bbfreeze/non-CPython
@@ -25,7 +26,7 @@ def get_versions(verbose=False):
     # ought to be the setup.py script). We prefer __file__ since that's more
     # robust in cases where setup.py was invoked in some weird way (e.g. pip)
     root = get_root()
-    versionfile_abs = os.path.join(root, versionfile_source)
+    versionfile_abs = os.path.join(root, config.versionfile_source)
 
     # extract version from first of _version.py, VCS command (e.g. 'git
     # describe'), parentdir. This is meant to work for developers using a
@@ -33,11 +34,12 @@ def get_versions(verbose=False):
     # and for users of a tarball/zipball created by 'git archive' or github's
     # download-from-tag feature or the equivalent in other VCSes.
 
-    get_keywords_f = vcs_function(VCS, "get_keywords")
-    versions_from_keywords_f = vcs_function(VCS, "versions_from_keywords")
+    get_keywords_f = vcs_function(config.VCS, "get_keywords")
+    versions_from_keywords_f = vcs_function(config.VCS,
+                                            "versions_from_keywords")
     if get_keywords_f and versions_from_keywords_f:
         vcs_keywords = get_keywords_f(versionfile_abs)
-        ver = versions_from_keywords_f(vcs_keywords, tag_prefix)
+        ver = versions_from_keywords_f(vcs_keywords, config.tag_prefix)
         if ver:
             if verbose:
                 print("got version from expanded keyword %s" % ver)
@@ -49,15 +51,15 @@ def get_versions(verbose=False):
             print("got version from file %s %s" % (versionfile_abs, ver))
         return ver
 
-    versions_from_vcs_f = vcs_function(VCS, "versions_from_vcs")
+    versions_from_vcs_f = vcs_function(config.VCS, "versions_from_vcs")
     if versions_from_vcs_f:
-        ver = versions_from_vcs_f(tag_prefix, root, verbose)
+        ver = versions_from_vcs_f(config.tag_prefix, root, verbose)
         if ver:
             if verbose:
                 print("got version from VCS %s" % ver)
             return ver
 
-    ver = versions_from_parentdir(parentdir_prefix, root, verbose)
+    ver = versions_from_parentdir(config.parentdir_prefix, root, verbose)
     if ver:
         if verbose:
             print("got version from parentdir %s" % ver)
@@ -70,5 +72,5 @@ def get_versions(verbose=False):
             "dirty": None, "error": "unable to compute version"}
 
 
-def get_version(verbose=False):
-    return get_versions(verbose=verbose)["version"]
+def get_version():
+    return get_versions()["version"]

--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -1,12 +1,14 @@
 
-def get_versions(verbose=False):
+def get_versions():
     # I am in _version.py, which lives at ROOT/VERSIONFILE_SOURCE. If we have
     # __file__, we can work backwards from there to the root. Some
     # py2exe/bbfreeze/non-CPython implementations don't do __file__, in which
     # case we can only use expanded keywords.
 
+    config = get_config()
     keywords = {"refnames": git_refnames, "full": git_full}
-    ver = git_versions_from_keywords(keywords, tag_prefix, verbose)
+    verbose = config.verbose
+    ver = git_versions_from_keywords(keywords, config.tag_prefix, verbose)
     if ver:
         return ver
 
@@ -15,15 +17,15 @@ def get_versions(verbose=False):
         # versionfile_source is the relative path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
-        for i in versionfile_source.split('/'):
+        for i in config.versionfile_source.split('/'):
             root = os.path.dirname(root)
     except NameError:
         return {"version": "0+unknown", "full-revisionid": None,
                 "dirty": None,
                 "error": "unable to find root of source tree"}
 
-    return (git_versions_from_vcs(tag_prefix, root, verbose)
-            or versions_from_parentdir(parentdir_prefix, root, verbose)
+    return (git_versions_from_vcs(config.tag_prefix, root, verbose)
+            or versions_from_parentdir(config.parentdir_prefix, root, verbose)
             or {"version": "0+unknown", "full-revisionid": None,
                 "dirty": None,
                 "error": "unable to compute version"})

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -17,7 +17,15 @@ import sys
 git_refnames = "%(DOLLAR)sFormat:%%d%(DOLLAR)s"
 git_full = "%(DOLLAR)sFormat:%%H%(DOLLAR)s"
 
-# these strings are filled in when 'setup.py versioneer' creates _version.py
-tag_prefix = "%(TAG_PREFIX)s"
-parentdir_prefix = "%(PARENTDIR_PREFIX)s"
-versionfile_source = "%(VERSIONFILE_SOURCE)s"
+class VersioneerConfig:
+    pass
+
+def get_config():
+    # these strings are filled in when 'setup.py versioneer' creates _version.py
+    config = VersioneerConfig()
+    config.VCS = "git"
+    config.tag_prefix = "%(TAG_PREFIX)s"
+    config.parentdir_prefix = "%(PARENTDIR_PREFIX)s"
+    config.versionfile_source = "%(VERSIONFILE_SOURCE)s"
+    config.verbose = False
+    return config

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -17,11 +17,14 @@ import sys
 git_refnames = "%(DOLLAR)sFormat:%%d%(DOLLAR)s"
 git_full = "%(DOLLAR)sFormat:%%H%(DOLLAR)s"
 
+
 class VersioneerConfig:
     pass
 
+
 def get_config():
-    # these strings are filled in when 'setup.py versioneer' creates _version.py
+    # these strings are filled in when 'setup.py versioneer' creates
+    # _version.py
     config = VersioneerConfig()
     config.VCS = "git"
     config.tag_prefix = "%(TAG_PREFIX)s"

--- a/src/header.py
+++ b/src/header.py
@@ -55,35 +55,44 @@ SAMPLE_CONFIG = """
 
 """
 
-config = configparser.SafeConfigParser()
-try:
-    setup_cfg = os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                             "setup.cfg")
-except NameError:
-    setup_cfg = "setup.cfg"
-try:
-    with open(setup_cfg, "r") as f:
-        config.readfp(f)
-    VCS = config.get("versioneer", "VCS")
-except (EnvironmentError, configparser.NoSectionError,
-        configparser.NoOptionError) as e:
-    if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
-        print("Adding sample versioneer config to setup.cfg", file=sys.stderr)
-        with open(setup_cfg, "a") as f:
-            f.write(SAMPLE_CONFIG)
-    print(CONFIG_ERROR, file=sys.stderr)
-    sys.exit(1)
+class VersioneerConfig:
+    pass
 
 
-def get_config_or_none(config, name):
-    if config.has_option("versioneer", name):
-        return config.get("versioneer", name)
-    return None
-versionfile_source = get_config_or_none(config, "versionfile_source")
-versionfile_build = get_config_or_none(config, "versionfile_build")
-tag_prefix = get_config_or_none(config, "tag_prefix")
-parentdir_prefix = get_config_or_none(config, "parentdir_prefix")
-del setup_cfg, config, get_config_or_none
+def get_config():
+    parser = configparser.SafeConfigParser()
+    try:
+        setup_cfg = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                 "setup.cfg")
+    except NameError:
+        setup_cfg = "setup.cfg"
+    try:
+        with open(setup_cfg, "r") as f:
+            parser.readfp(f)
+        VCS = parser.get("versioneer", "VCS")
+    except (EnvironmentError, configparser.NoSectionError,
+            configparser.NoOptionError) as e:
+        if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
+            print("Adding sample versioneer config to setup.cfg",
+                  file=sys.stderr)
+            with open(setup_cfg, "a") as f:
+                f.write(SAMPLE_CONFIG)
+        print(CONFIG_ERROR, file=sys.stderr)
+        sys.exit(1)
+
+    def get(parser, name):
+        if parser.has_option("versioneer", name):
+            return parser.get("versioneer", name)
+        return None
+    config = VersioneerConfig()
+    config.VCS = VCS
+    config.versionfile_source = get(parser, "versionfile_source")
+    config.versionfile_build = get(parser, "versionfile_build")
+    config.tag_prefix = get(parser, "tag_prefix")
+    config.parentdir_prefix = get(parser, "parentdir_prefix")
+    config.verbose = get(parser, "verbose")
+    return config
+
 
 # these dictionaries contain VCS-specific tools
 LONG_VERSION_PY = {}

--- a/src/header.py
+++ b/src/header.py
@@ -55,6 +55,7 @@ SAMPLE_CONFIG = """
 
 """
 
+
 class VersioneerConfig:
     pass
 

--- a/src/header.py
+++ b/src/header.py
@@ -5,7 +5,10 @@
 @README@
 """
 
-import ConfigParser
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 import errno
 import json
 import os
@@ -16,7 +19,7 @@ from distutils.command.build import build as _build
 from distutils.command.sdist import sdist as _sdist
 from distutils.core import Command
 
-config = ConfigParser.SafeConfigParser()
+config = configparser.SafeConfigParser()
 try:
     setup_cfg = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                              "setup.cfg")
@@ -27,7 +30,7 @@ try:
         config.readfp(f)
     VCS = config.get("versioneer", "VCS")
 except (EnvironmentError,
-        ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+        configparser.NoSectionError, configparser.NoOptionError):
     raise Exception("Versioneer is now configured with setup.cfg,"
                     " not setup.py. Please see the README or"
                     " versioneer.py for details.")

--- a/src/header.py
+++ b/src/header.py
@@ -5,6 +5,7 @@
 @README@
 """
 
+from __future__ import print_function
 try:
     import configparser
 except ImportError:
@@ -19,6 +20,41 @@ from distutils.command.build import build as _build
 from distutils.command.sdist import sdist as _sdist
 from distutils.core import Command
 
+CONFIG_ERROR = """
+setup.cfg is missing the necessary Versioneer configuration. You need
+a section like:
+
+ [versioneer]
+ VCS = git
+ versionfile_source = src/myproject/_version.py
+ versionfile_build = myproject/_version.py
+ tag_prefix = ""
+ parentdir_prefix = myproject-
+
+You will also need to edit your setup.py to use the results:
+
+ import versioneer
+ setup(version=versioneer.get_version(),
+       cmdclass=versioneer.get_cmdclass(), ...)
+
+Please read the docstring in ./versioneer.py for configuration instructions,
+edit setup.cfg, and re-run the installer or 'python versioneer.py setup'.
+"""
+
+SAMPLE_CONFIG = """
+# See the docstring in versioneer.py for instructions. Note that you must
+# re-run 'versioneer.py setup' after changing this section, and commit the
+# resulting files.
+
+[versioneer]
+#VCS = git
+#versionfile_source =
+#versionfile_build =
+#tag_prefix =
+#parentdir_prefix =
+
+"""
+
 config = configparser.SafeConfigParser()
 try:
     setup_cfg = os.path.join(os.path.dirname(os.path.realpath(__file__)),
@@ -29,11 +65,14 @@ try:
     with open(setup_cfg, "r") as f:
         config.readfp(f)
     VCS = config.get("versioneer", "VCS")
-except (EnvironmentError,
-        configparser.NoSectionError, configparser.NoOptionError):
-    raise Exception("Versioneer is now configured with setup.cfg,"
-                    " not setup.py. Please see the README or"
-                    " versioneer.py for details.")
+except (EnvironmentError, configparser.NoSectionError,
+        configparser.NoOptionError) as e:
+    if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
+        print("Adding sample versioneer config to setup.cfg", file=sys.stderr)
+        with open(setup_cfg, "a") as f:
+            f.write(SAMPLE_CONFIG)
+    print(CONFIG_ERROR, file=sys.stderr)
+    sys.exit(1)
 
 
 def get_config_or_none(config, name):

--- a/src/header.py
+++ b/src/header.py
@@ -5,6 +5,7 @@
 @README@
 """
 
+import ConfigParser
 import errno
 import json
 import os
@@ -15,13 +16,32 @@ from distutils.command.build import build as _build
 from distutils.command.sdist import sdist as _sdist
 from distutils.core import Command
 
-# these configuration settings will be overridden by setup.py after it
-# imports us
-versionfile_source = None
-versionfile_build = None
-tag_prefix = None
-parentdir_prefix = None
-VCS = None
+config = ConfigParser.SafeConfigParser()
+try:
+    setup_cfg = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                             "setup.cfg")
+except NameError:
+    setup_cfg = "setup.cfg"
+try:
+    with open(setup_cfg, "r") as f:
+        config.readfp(f)
+    VCS = config.get("versioneer", "VCS")
+except (EnvironmentError,
+        ConfigParser.NoSectionError, ConfigParser.NoOptionError):
+    raise Exception("Versioneer is now configured with setup.cfg,"
+                    " not setup.py. Please see the README or"
+                    " versioneer.py for details.")
+
+
+def get_config_or_none(config, name):
+    if config.has_option("versioneer", name):
+        return config.get("versioneer", name)
+    return None
+versionfile_source = get_config_or_none(config, "versionfile_source")
+versionfile_build = get_config_or_none(config, "versionfile_build")
+tag_prefix = get_config_or_none(config, "tag_prefix")
+parentdir_prefix = get_config_or_none(config, "parentdir_prefix")
+del setup_cfg, config, get_config_or_none
 
 # these dictionaries contain VCS-specific tools
 LONG_VERSION_PY = {}

--- a/src/installer.py
+++ b/src/installer.py
@@ -20,4 +20,5 @@ if os.path.exists("versioneer.py"):
 with open("versioneer.py", "wb") as f:
     f.write(v)
 print("versioneer.py (%s) installed into local tree" % newver)
-print("Now please follow instructions in the docstring.")
+print("Now running 'versioneer.py setup' to install the generated files..")
+os.execl(sys.executable, sys.executable, "versioneer.py", "setup")

--- a/src/installer.py
+++ b/src/installer.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python
 
-import os, base64
+import os, sys, base64
 
 VERSIONEER_b64 = """
 @VERSIONEER-INSTALLER@
 """
 
+newver = "@VERSIONEER-VERSION@"
 v = base64.b64decode(VERSIONEER_b64)
 if os.path.exists("versioneer.py"):
-    print("overwriting existing versioneer.py")
+    for line in open("versioneer.py").readlines()[:5]:
+        if line.startswith("# Version: "):
+            oldver = line[len("# Version: "):].strip()
+            if oldver != newver:
+                print("replacing old versioneer.py (%s)" % oldver)
+            break
+    else:
+        print("overwriting existing versioneer.py")
 with open("versioneer.py", "wb") as f:
     f.write(v)
-print("versioneer.py (@VERSIONEER-VERSION@) installed into local tree")
+print("versioneer.py (%s) installed into local tree" % newver)
 print("Now please follow instructions in the docstring.")

--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -10,17 +10,19 @@ del get_versions
 
 
 def do_setup():
-    print(" creating %s" % versionfile_source)
-    with open(versionfile_source, "w") as f:
-        assert VCS is not None, "please set versioneer.VCS"
-        LONG = LONG_VERSION_PY[VCS]
+    config = get_config()
+    print(" creating %s" % config.versionfile_source)
+    with open(config.versionfile_source, "w") as f:
+        assert config.VCS is not None, "please set versioneer.VCS"
+        LONG = LONG_VERSION_PY[config.VCS]
         f.write(LONG % {"DOLLAR": "$",
-                        "TAG_PREFIX": tag_prefix,
-                        "PARENTDIR_PREFIX": parentdir_prefix,
-                        "VERSIONFILE_SOURCE": versionfile_source,
+                        "TAG_PREFIX": config.tag_prefix,
+                        "PARENTDIR_PREFIX": config.parentdir_prefix,
+                        "VERSIONFILE_SOURCE": config.versionfile_source,
                         })
 
-    ipy = os.path.join(os.path.dirname(versionfile_source), "__init__.py")
+    ipy = os.path.join(os.path.dirname(config.versionfile_source),
+                       "__init__.py")
     if os.path.exists(ipy):
         try:
             with open(ipy, "r") as f:
@@ -61,18 +63,18 @@ def do_setup():
             f.write("include versioneer.py\n")
     else:
         print(" 'versioneer.py' already in MANIFEST.in")
-    if versionfile_source not in simple_includes:
+    if config.versionfile_source not in simple_includes:
         print(" appending versionfile_source ('%s') to MANIFEST.in" %
-              versionfile_source)
+              config.versionfile_source)
         with open(manifest_in, "a") as f:
-            f.write("include %s\n" % versionfile_source)
+            f.write("include %s\n" % config.versionfile_source)
     else:
         print(" versionfile_source already in MANIFEST.in")
 
     # Make VCS-specific changes. For git, this means creating/changing
     # .gitattributes to mark _version.py for export-time keyword
     # substitution.
-    do_vcs_install(manifest_in, versionfile_source, ipy)
+    do_vcs_install(manifest_in, config.versionfile_source, ipy)
 
 
 def scan_setup_py():

--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -1,0 +1,103 @@
+
+import os  # --STRIP DURING BUILD
+import sys  # --STRIP DURING BUILD
+
+INIT_PY_SNIPPET = """
+from ._version import get_versions
+__version__ = get_versions()['version']
+del get_versions
+"""
+
+
+def do_setup():
+    print(" creating %s" % versionfile_source)
+    with open(versionfile_source, "w") as f:
+        assert VCS is not None, "please set versioneer.VCS"
+        LONG = LONG_VERSION_PY[VCS]
+        f.write(LONG % {"DOLLAR": "$",
+                        "TAG_PREFIX": tag_prefix,
+                        "PARENTDIR_PREFIX": parentdir_prefix,
+                        "VERSIONFILE_SOURCE": versionfile_source,
+                        })
+
+    ipy = os.path.join(os.path.dirname(versionfile_source), "__init__.py")
+    if os.path.exists(ipy):
+        try:
+            with open(ipy, "r") as f:
+                old = f.read()
+        except EnvironmentError:
+            old = ""
+        if INIT_PY_SNIPPET not in old:
+            print(" appending to %s" % ipy)
+            with open(ipy, "a") as f:
+                f.write(INIT_PY_SNIPPET)
+        else:
+            print(" %s unmodified" % ipy)
+    else:
+        print(" %s doesn't exist, ok" % ipy)
+        ipy = None
+
+    # Make sure both the top-level "versioneer.py" and versionfile_source
+    # (PKG/_version.py, used by runtime code) are in MANIFEST.in, so
+    # they'll be copied into source distributions. Pip won't be able to
+    # install the package without this.
+    manifest_in = os.path.join(get_root(), "MANIFEST.in")
+    simple_includes = set()
+    try:
+        with open(manifest_in, "r") as f:
+            for line in f:
+                if line.startswith("include "):
+                    for include in line.split()[1:]:
+                        simple_includes.add(include)
+    except EnvironmentError:
+        pass
+    # That doesn't cover everything MANIFEST.in can do
+    # (http://docs.python.org/2/distutils/sourcedist.html#commands), so
+    # it might give some false negatives. Appending redundant 'include'
+    # lines is safe, though.
+    if "versioneer.py" not in simple_includes:
+        print(" appending 'versioneer.py' to MANIFEST.in")
+        with open(manifest_in, "a") as f:
+            f.write("include versioneer.py\n")
+    else:
+        print(" 'versioneer.py' already in MANIFEST.in")
+    if versionfile_source not in simple_includes:
+        print(" appending versionfile_source ('%s') to MANIFEST.in" %
+              versionfile_source)
+        with open(manifest_in, "a") as f:
+            f.write("include %s\n" % versionfile_source)
+    else:
+        print(" versionfile_source already in MANIFEST.in")
+
+    # Make VCS-specific changes. For git, this means creating/changing
+    # .gitattributes to mark _version.py for export-time keyword
+    # substitution.
+    do_vcs_install(manifest_in, versionfile_source, ipy)
+
+
+def scan_setup_py():
+    found = set()
+    with open("setup.py", "r") as f:
+        for line in f.readlines():
+            if "import versioneer" in line:
+                found.add("import")
+            if "versioneer.get_cmdclass()" in line:
+                found.add("cmdclass")
+            if "versioneer.get_version()" in line:
+                found.add("get_version")
+    if len(found) != 3:
+        print("")
+        print("Your setup.py appears to be missing some important items")
+        print("(but I might be wrong). Please make sure it has something")
+        print("roughly like the following:")
+        print("")
+        print(" import versioneer")
+        print(" setup( version=versioneer.get_version(),")
+        print("        cmdclass=versioneer.get_cmdclass(),  ...)")
+        print("")
+
+if __name__ == "__main__":
+    cmd = sys.argv[1]
+    if cmd == "setup":
+        do_setup()
+        scan_setup_py()

--- a/test/demoapp-script-only/setup.cfg
+++ b/test/demoapp-script-only/setup.cfg
@@ -1,0 +1,6 @@
+[versioneer]
+versionfile_source = src/demo/_version.py
+versionfile_build =
+tag_prefix = demo-
+parentdir_prefix = demo-
+VCS = @VCS@

--- a/test/demoapp-script-only/setup.py
+++ b/test/demoapp-script-only/setup.py
@@ -3,11 +3,6 @@ import os, tempfile
 from distutils.core import setup
 from distutils.command.build_scripts import build_scripts
 import versioneer
-versioneer.versionfile_source = "src/demo/_version.py"
-versioneer.versionfile_build = None
-versioneer.tag_prefix = "demo-"
-versioneer.parentdir_prefix = "demo-"
-versioneer.VCS = "@VCS@"
 commands = versioneer.get_cmdclass().copy()
 
 class my_build_scripts(build_scripts):

--- a/test/demoapp/setup.cfg
+++ b/test/demoapp/setup.cfg
@@ -1,0 +1,7 @@
+
+[versioneer]
+versionfile_source = src/demo/_version.py
+versionfile_build = demo/_version.py
+tag_prefix = demo-
+parentdir_prefix = demo-
+VCS = @VCS@

--- a/test/demoapp/setup.py
+++ b/test/demoapp/setup.py
@@ -1,11 +1,6 @@
 
 from distutils.core import setup
 import versioneer
-versioneer.versionfile_source = "src/demo/_version.py"
-versioneer.versionfile_build = "demo/_version.py"
-versioneer.tag_prefix = "demo-"
-versioneer.parentdir_prefix = "demo-"
-versioneer.VCS = "@VCS@"
 commands = versioneer.get_cmdclass().copy()
 
 setup(name="demo",

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -189,12 +189,12 @@ class Repo(unittest.TestCase):
         self.git("tag", "demo-4.0", workdir=self.testdir)
 
         shutil.copytree(demoapp_dir, self.subpath("demoapp"))
-        setup_py_fn = os.path.join(self.subpath("demoapp"), "setup.py")
-        with open(setup_py_fn, "r") as f:
-            setup_py = f.read()
-        setup_py = setup_py.replace("@VCS@", "git")
-        with open(setup_py_fn, "w") as f:
-            f.write(setup_py)
+        setup_cfg_fn = os.path.join(self.subpath("demoapp"), "setup.cfg")
+        with open(setup_cfg_fn, "r") as f:
+            setup_cfg = f.read()
+        setup_cfg = setup_cfg.replace("@VCS@", "git")
+        with open(setup_cfg_fn, "w") as f:
+            f.write(setup_cfg)
         shutil.copyfile("versioneer.py", self.subpath("demoapp/versioneer.py"))
         self.git("init")
         self.git("add", "--all")

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -207,8 +207,8 @@ class Repo(unittest.TestCase):
                         "--version", workdir=self.testdir)
         self.assertEqual(v, "0+untagged.1.g%s" % full[:7])
 
-        out = self.python("setup.py", "versioneer").splitlines()
-        self.assertEqual(out[0], "running versioneer")
+        out = self.python("setup.py", "setup_versioneer").splitlines()
+        self.assertEqual(out[0], "running setup_versioneer")
         self.assertEqual(out[1], " creating src/demo/_version.py")
         if script_only:
             self.assertEqual(out[2], " src/demo/__init__.py doesn't exist, ok")
@@ -237,8 +237,8 @@ class Repo(unittest.TestCase):
         self.git("commit", "-m", "add _version stuff")
 
         # "setup.py versioneer" should be idempotent
-        out = self.python("setup.py", "versioneer").splitlines()
-        self.assertEqual(out[0], "running versioneer")
+        out = self.python("setup.py", "setup_versioneer").splitlines()
+        self.assertEqual(out[0], "running setup_versioneer")
         self.assertEqual(out[1], " creating src/demo/_version.py")
         if script_only:
             self.assertEqual(out[2], " src/demo/__init__.py doesn't exist, ok")

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -207,15 +207,14 @@ class Repo(unittest.TestCase):
                         "--version", workdir=self.testdir)
         self.assertEqual(v, "0+untagged.1.g%s" % full[:7])
 
-        out = self.python("setup.py", "setup_versioneer").splitlines()
-        self.assertEqual(out[0], "running setup_versioneer")
-        self.assertEqual(out[1], " creating src/demo/_version.py")
+        out = self.python("versioneer.py", "setup").splitlines()
+        self.assertEqual(out[0], "creating src/demo/_version.py")
         if script_only:
-            self.assertEqual(out[2], " src/demo/__init__.py doesn't exist, ok")
+            self.assertEqual(out[1], " src/demo/__init__.py doesn't exist, ok")
         else:
-            self.assertEqual(out[2], " appending to src/demo/__init__.py")
-        self.assertEqual(out[3], " appending 'versioneer.py' to MANIFEST.in")
-        self.assertEqual(out[4], " appending versionfile_source ('src/demo/_version.py') to MANIFEST.in")
+            self.assertEqual(out[1], " appending to src/demo/__init__.py")
+        self.assertEqual(out[2], " appending 'versioneer.py' to MANIFEST.in")
+        self.assertEqual(out[3], " appending versionfile_source ('src/demo/_version.py') to MANIFEST.in")
         out = set(self.git("status", "--porcelain").splitlines())
         # Many folks have a ~/.gitignore with ignores .pyc files, but if they
         # don't, it will show up in the status here. Ignore it.
@@ -236,16 +235,15 @@ class Repo(unittest.TestCase):
             self.assertEqual(i[-1], "del get_versions")
         self.git("commit", "-m", "add _version stuff")
 
-        # "setup.py versioneer" should be idempotent
-        out = self.python("setup.py", "setup_versioneer").splitlines()
-        self.assertEqual(out[0], "running setup_versioneer")
-        self.assertEqual(out[1], " creating src/demo/_version.py")
+        # "versioneer.py setup" should be idempotent
+        out = self.python("versioneer.py", "setup").splitlines()
+        self.assertEqual(out[0], "creating src/demo/_version.py")
         if script_only:
-            self.assertEqual(out[2], " src/demo/__init__.py doesn't exist, ok")
+            self.assertEqual(out[1], " src/demo/__init__.py doesn't exist, ok")
         else:
-            self.assertEqual(out[2], " src/demo/__init__.py unmodified")
-        self.assertEqual(out[3], " 'versioneer.py' already in MANIFEST.in")
-        self.assertEqual(out[4], " versionfile_source already in MANIFEST.in")
+            self.assertEqual(out[1], " src/demo/__init__.py unmodified")
+        self.assertEqual(out[2], " 'versioneer.py' already in MANIFEST.in")
+        self.assertEqual(out[3], " versionfile_source already in MANIFEST.in")
         out = set(self.git("status", "--porcelain").splitlines())
         out.discard("?? versioneer.pyc")
         out.discard("?? __pycache__/")


### PR DESCRIPTION
This replaces the funky attribute-assignment-after-import that was used to configure Versioneer with a new section in your `setup.cfg`. Much cleaner.

It also removes the `setup.py versioneer` command, which was used to install `_version.py` in your source tree (and update .gitattributes and things). That functionality is now managed by `versioneer-installer`, which is how you get the `versioneer.py` into your tree in the first place. (And if you really need to, you can run `python versioneer.py setup` to do the same thing without replacing the `versioneer.py`).

This still needs some tweaks: running `versioneer-installer` on a source tree that does not yet have the right stuff in `setup.cfg` gives you an exception (that does point to the right docs, but still). It'd be nice if the first-run or upgrade-to-setup.cfg experience were prettier.
