### PR TITLE
setting  tag_prefix = ""  in py34 produces error

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ First, decide on values for the following configuration variables:
   a string, like 'PROJECTNAME-', which appears at the start of all VCS tags.
   If your tags look like 'myproject-1.2.0', then you should use
   tag_prefix='myproject-'. If you use unprefixed tags like '1.2.0', this
-  should be an empty string.
+  should be an empty string, using single quotes.
 
 * `parentdir_prefix`:
 
@@ -155,7 +155,7 @@ To versioneer-enable your project:
   style = pep440
   versionfile_source = src/myproject/_version.py
   versionfile_build = myproject/_version.py
-  tag_prefix = ""
+  tag_prefix = ''
   parentdir_prefix = myproject-
   ````
 


### PR DESCRIPTION
Change readme to say to use single quotes instead of double quotes

```
py34 runtests: commands[2] | python setup.py bdist_wheel
Traceback (most recent call last):
  File "/root/netshow-core/netshow/ez_setup.py", line 151, in use_setuptools
    import pkg_resources
  File
"/root/netshow-core/netshow/.tox/py34/lib/python3.4/site-packages/pkg_resources/__init__.py",
line 3074, in <module>
    @_call_aside
  File
"/root/netshow-core/netshow/.tox/py34/lib/python3.4/site-packages/pkg_resources/__init__.py",
line 3060, in _call_aside
    f(*args, **kwargs)
  File
"/root/netshow-core/netshow/.tox/py34/lib/python3.4/site-packages/pkg_resources/__init__.py",
line 3099, in _initialize_master_working_set
    add_activation_listener(lambda dist: dist.activate())
  File
"/root/netshow-core/netshow/.tox/py34/lib/python3.4/site-packages/pkg_resources/__init__.py",
line 959, in subscribe
    callback(dist)
  File
"/root/netshow-core/netshow/.tox/py34/lib/python3.4/site-packages/pkg_resources/__init__.py",
line 3099, in <lambda>
    add_activation_listener(lambda dist: dist.activate())
  File
"/root/netshow-core/netshow/.tox/py34/lib/python3.4/site-packages/pkg_resources/__init__.py",
line 2618, in activate
    declare_namespace(pkg)
  File
"/root/netshow-core/netshow/.tox/py34/lib/python3.4/site-packages/pkg_resources/__init__.py",
line 2209, in declare_namespace
    _handle_ns(packageName, path_item)
  File
"/root/netshow-core/netshow/.tox/py34/lib/python3.4/site-packages/pkg_resources/__init__.py",
line 2176, in _handle_ns
    loader.load_module(packageName)
  File "/root/netshow-core/netshow/netshow/__init__.py", line 4, in <module>
    from ._version import get_versions
  File "/root/netshow-core/netshow/netshow/_version.py", line 460
    "error": "unable to compute version"}
                                        ^
SyntaxError: EOF while scanning triple-quoted string literal

```

It is because in <projectname>/_version.py,  ``tag_prefix = """"``