### PR TITLE
fix problem with pip install not installing non .py files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /MANIFEST
 /dist/
 /versioneer.egg-info/
+/.idea

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -58,7 +58,11 @@ def get_cmdclass():
     #  setuptools/install -> bdist_egg ->..
     #  setuptools/develop -> ?
 
-    from distutils.command.build_py import build_py as _build_py
+    # we override different "build_py" commands for both environments
+    if "setuptools" in sys.modules:
+        from setuptools.command.build_py import build_py as _build_py
+    else:
+        from distutils.command.build_py import build_py as _build_py
 
     class cmd_build_py(_build_py):
         def run(self):


### PR DESCRIPTION
Without this change I had my non .py files in tar.gz but `pip install package.tar.gz` was not coping those non .py files. 