### PR TITLE
b64decode in python3.2 accepts only bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,14 @@ branches:
 python:
   - "2.6"
   - "2.7"
+  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
   - "pypy"
   - "pypy3"
 install:
-  - pip install -U tox virtualenv
+# virtualenv>=14.0.0 is incompatible with python 3.2
+  - if [[ $TRAVIS_PYTHON_VERSION != '3.2' ]]; then pip install -U tox virtualenv; else travis_retry pip install tox "virtualenv<14.0.0"; fi
 script:
-  - tox -e py
+  - tox -e py${TRAVIS_PYTHON_VERSION}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Versioneer
 * https://github.com/warner/python-versioneer
 * Brian Warner
 * License: Public Domain
-* Compatible With: python2.6, 2.7, 3.3, 3.4, 3.5, and pypy
+* Compatible With: python2.6, 2.7, 3.2, 3.3, 3.4, 3.5, and pypy
 * [![Latest Version]
 (https://pypip.in/version/versioneer/badge.svg?style=flat)
 ](https://pypi.python.org/pypi/versioneer/)

--- a/setup.py
+++ b/setup.py
@@ -180,5 +180,6 @@ setup(
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5"
         ],
     )

--- a/src/installer.py
+++ b/src/installer.py
@@ -20,7 +20,7 @@ if command != "install":
     print("Usage: versioneer install")
     sys.exit(1)
 
-v = base64.b64decode(VERSIONEER_b64)
+v = base64.b64decode(VERSIONEER_b64.encode('ASCII'))
 if os.path.exists("versioneer.py"):
     for line in open("versioneer.py").readlines()[:5]:
         if line.startswith("# Version: "):

--- a/tox.ini
+++ b/tox.ini
@@ -3,17 +3,30 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
+# env names corresponding to py${TRAVIS_PYTHON_VERSION}, see .travis.yml
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = py2.6,py2.7,py3.2,py3.3,py3.4,py3.5,pypypy,pypypy3
 skip_missing_interpreters = True
 
 [testenv]
+basepython =
+           py2.6: python2.6
+           py2.7: python2.7
+           py3.2: python3.2
+           py3.3: python3.3
+           py3.4: python3.4
+           py3.5: python3.5
+           pypypy: pypy
+           pypypy3: pypy3
+
+# virtualenv>=14.0.0 is incompatible with python 3.2
 deps =
     pyflakes
     flake8
     wheel
     setuptools
-    virtualenv
+    py3.2: virtualenv<14.0.0
+    py2.6,py2.7,py3.3,py3.4,py3.5,pypypy,pypypy3: virtualenv
     discover
     flake8-docstrings
 


### PR DESCRIPTION
py32 added to the test suite as special case with virtualenv < 14.0
updated README.md and setup.py with correct python versions
tox configuration modified accordingly