### PR TITLE
Remove unused import in _version.py from file

### DIFF
--- a/src/from_file.py
+++ b/src/from_file.py
@@ -6,7 +6,6 @@ SHORT_VERSION_PY = """
 # of this file.
 
 import json
-import sys
 
 version_json = '''
 %s


### PR DESCRIPTION
The `_version.py` file generated for a from_file environment contained an unused `import sys` which occasionally could cause linting failures.