### PR TITLE
tox.ini: avoid newer flake8 on older pythons

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,11 @@ basepython =
            pypypy3: pypy3
 
 # virtualenv>=14.0.0 is incompatible with python 3.2
+# flake8>=3.0.0 is incompatible with 2.6,3.2,3.3
 deps =
     pyflakes
-    flake8
+    py2.6,py3.2,py3.3: flake8<3.0.0
+    py2.7,py3.4,py3.5,pypypy,pypypy3: flake8
     wheel
     setuptools
     py3.2: virtualenv<14.0.0


### PR DESCRIPTION
flake8-3.0.0 dropped support for py2.6, py3.2, and py3.3 . The most
recent flake8 uses python features unavailable in those versions (like
OrderedDict). To continue testing versioneer against those old pythons,
we install an older flake8 (2.6.2 was the last pre-3.0.0 release) when
we're using one of them.