### PR TITLE
travis: 3.6 is supported now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.6-dev"
+  - "3.6"
+  - "nightly"
   - "pypy"
   - "pypy3"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,13 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "nightly"
   - "pypy"
   - "pypy3"
 install:
 # virtualenv>=14.0.0 is incompatible with python 3.2
   - if [[ $TRAVIS_PYTHON_VERSION != '3.2' ]]; then pip install -U tox virtualenv; else travis_retry pip install tox "virtualenv<14.0.0"; fi
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6-dev' ]]; then tox -e py3.6; else tox -e py${TRAVIS_PYTHON_VERSION}; fi
+  - tox -e py${TRAVIS_PYTHON_VERSION}
 matrix:
   allow_failures:
     - python: "pypy3"


### PR DESCRIPTION
Also add 'nightly' to look for problems with the upcoming python
release (currently 3.7-dev).