### PR TITLE
Render the badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,8 @@ The Versioneer
 * Brian Warner
 * License: Public Domain
 * Compatible With: python2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6, and pypy
-* [![Latest Version]
-(https://pypip.in/version/versioneer/badge.svg?style=flat)
-](https://pypi.python.org/pypi/versioneer/)
-* [![Build Status]
-(https://travis-ci.org/warner/python-versioneer.png?branch=master)
-](https://travis-ci.org/warner/python-versioneer)
+* [![Latest Version](https://img.shields.io/pypi/v/versioneer.svg)](https://pypi.python.org/pypi/versioneer/)
+* [![Build Status](https://travis-ci.org/warner/python-versioneer.png?branch=master)](https://travis-ci.org/warner/python-versioneer)
 
 This is a tool for managing a recorded version number in distutils-based
 python projects. The goal is to remove the tedious and error-prone "update


### PR DESCRIPTION
This renders the badges when viewing the `README.md` on GitHub.

You can click "Display the Rich Diff" below (it's a Page icon at the top-right of the diff below) or [click here](https://github.com/philschatz/python-versioneer/blob/patch-1/README.md)