### PR TITLE
Fix flake8

### DIFF
--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -56,7 +56,7 @@ HANDLERS = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator
-    """Decorator to mark a method as the handler for a particular VCS."""
+    """Create decorator to mark a method as the handler of a VCS."""
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:

--- a/src/header.py
+++ b/src/header.py
@@ -101,7 +101,7 @@ HANDLERS = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator
-    """Decorator to mark a method as the handler for a particular VCS."""
+    """Create decorator to mark a method as the handler of a VCS."""
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:

--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -52,7 +52,7 @@ del get_versions
 
 
 def do_setup():
-    """Main VCS-independent setup function for installing Versioneer."""
+    """Do main VCS-independent setup function for installing Versioneer."""
     root = get_root()
     try:
         cfg = get_config_from_root(root)

--- a/tox.ini
+++ b/tox.ini
@@ -26,12 +26,14 @@ deps =
     pyflakes
     py2.6,py3.2,py3.3: flake8<3.0.0
     py2.7,py3.4,py3.5,py3.6,pypypy,pypypy3: flake8
+    py2.6,py3.2: pydocstyle<2
+    py2.6,py3.2: flake8-docstrings<1.1.0
+    py2.7,py3.3,py3.4,py3.5,py3.6,pypypy,pypypy3: flake8-docstrings
     wheel
     setuptools
     py3.2: virtualenv<14.0.0
     py2.6,py2.7,py3.3,py3.4,py3.5,py3.6,pypypy,pypypy3: virtualenv
     discover
-    flake8-docstrings
     pep8
 
 commands =


### PR DESCRIPTION
pydocstyle 2.0.0 is released, without support for Python 2.6 or 3.2.

flake8-docstrings 1.1.0 uses pycodestyle 2.0.0 features, so it also must be downgraded on those Python versions.

Finally, pycodestyle has tighter checking of the first word in docstrings, for imperative mode, so three docstrings need slight modifying.