### PR TITLE
Use tox-travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,9 @@ python:
   - "pypy"
   - "pypy3"
 install:
-# virtualenv>=14.0.0 is incompatible with python 3.2
-  - if [[ $TRAVIS_PYTHON_VERSION != '3.2' ]]; then pip install -U tox virtualenv; else travis_retry pip install tox "virtualenv<14.0.0"; fi
+  - pip install tox-travis
 script:
-  - tox -e py${TRAVIS_PYTHON_VERSION}
+  - tox
 matrix:
   allow_failures:
     - python: "pypy3"

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -56,7 +56,7 @@ HANDLERS = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator
-    """Decorator to mark a method as the handler for a particular VCS."""
+    """Create decorator to mark a method as the handler of a VCS."""
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:

--- a/src/header.py
+++ b/src/header.py
@@ -101,7 +101,7 @@ HANDLERS = {}
 
 
 def register_vcs_handler(vcs, method):  # decorator
-    """Decorator to mark a method as the handler for a particular VCS."""
+    """Create decorator to mark a method as the handler of a VCS."""
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:

--- a/src/setupfunc.py
+++ b/src/setupfunc.py
@@ -52,7 +52,7 @@ del get_versions
 
 
 def do_setup():
-    """Main VCS-independent setup function for installing Versioneer."""
+    """Do main VCS-independent setup function for installing Versioneer."""
     root = get_root()
     try:
         cfg = get_config_from_root(root)

--- a/tox.ini
+++ b/tox.ini
@@ -26,12 +26,14 @@ deps =
     pyflakes
     py2.6,py3.2,py3.3: flake8<3.0.0
     py2.7,py3.4,py3.5,py3.6,pypypy,pypypy3: flake8
+    py2.6,py3.2: pydocstyle<2
+    py2.6,py3.2: flake8-docstrings<1.1.0
+    py2.7,py3.3,py3.4,py3.5,py3.6,pypypy,pypypy3: flake8-docstrings
     wheel
     setuptools
     py3.2: virtualenv<14.0.0
     py2.6,py2.7,py3.3,py3.4,py3.5,py3.6,pypypy,pypypy3: virtualenv
     discover
-    flake8-docstrings
     pep8
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -3,36 +3,24 @@
 # test suite on all supported python versions. To use it, "pip install tox"
 # and then run "tox" from this directory.
 
-# env names corresponding to py${TRAVIS_PYTHON_VERSION}, see .travis.yml
 [tox]
-envlist = py2.6,py2.7,py3.2,py3.3,py3.4,py3.5,py3.6,pypypy,pypypy3
+envlist = py26,py27,py32,py33,py34,py35,py36,pypy,pypy3
 skip_missing_interpreters = True
 
 [testenv]
-basepython =
-           py2.6: python2.6
-           py2.7: python2.7
-           py3.2: python3.2
-           py3.3: python3.3
-           py3.4: python3.4
-           py3.5: python3.5
-           py3.6: python3.6
-           pypypy: pypy
-           pypypy3: pypy3
-
 # virtualenv>=14.0.0 is incompatible with python 3.2
 # flake8>=3.0.0 is incompatible with 2.6,3.2,3.3
 deps =
     pyflakes
-    py2.6,py3.2,py3.3: flake8<3.0.0
-    py2.7,py3.4,py3.5,py3.6,pypypy,pypypy3: flake8
-    py2.6,py3.2: pydocstyle<2
-    py2.6,py3.2: flake8-docstrings<1.1.0
-    py2.7,py3.3,py3.4,py3.5,py3.6,pypypy,pypypy3: flake8-docstrings
+    py26,py32,py33: flake8<3.0.0
+    py27,py34,py35,py36,pypy,pypy3: flake8
+    py26,py32: pydocstyle<2
+    py26,py32: flake8-docstrings<1.1.0
+    py27,py33,py34,py35,py36,pypy,pypy3: flake8-docstrings
     wheel
     setuptools
-    py3.2: virtualenv<14.0.0
-    py2.6,py2.7,py3.3,py3.4,py3.5,py3.6,pypypy,pypypy3: virtualenv
+    py32: virtualenv<14.0.0
+    py26,py27,py33,py34,py35,py36,pypy,pypy3: virtualenv
     discover
     pep8
 


### PR DESCRIPTION
This first version sits on top of https://github.com/warner/python-versioneer/pull/157 , so it has a green build.

[tox-travis](https://github.com/ryanhiebert/tox-travis) sets `TOXENV` and manages the tox dependencies, such as `virtualenv`, for Python 3.2 automatically.  (Note I am an occasionally contributor to `tox-travis`.)

This implicitly fixes one of the problems with the pypy3 builds, but isnt fixed entirely.

I must say that the 'trick' of adding prefix `py` to all tox testenv names is new to me, and I quite like it as quite inventive, but IMO it is better to "bend" Travis to work with tox standard tox testenv names, and tox-travis also provides a project where tox users can collaborate on problems wrt getting tox to work neatly with Travis.