### PR TITLE
[WIP] Allow overwritting of the fallback version number.

### DIFF
--- a/src/get_versions.py
+++ b/src/get_versions.py
@@ -82,7 +82,7 @@ def get_versions(verbose=False):
     if verbose:
         print("unable to compute version")
 
-    return {"version": "0+unknown", "full-revisionid": None,
+    return {"version": fallback_version + "+unknown", "full-revisionid": None,
             "dirty": None, "error": "unable to compute version",
             "date": None}
 

--- a/src/git/from_keywords.py
+++ b/src/git/from_keywords.py
@@ -80,11 +80,10 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
                     "full-revisionid": keywords["full"].strip(),
                     "dirty": False, "error": None,
                     "date": date}
-    # no suitable tags, so version is "0+unknown", but full hex is still there
+    # no suitable tags, so version is fallback_version + "+unknown",
+    # but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
+    return {"version": fallback_version + "+unknown",
             "full-revisionid": keywords["full"].strip(),
             "dirty": False, "error": "no suitable tags", "date": None}
-
-

--- a/src/git/long_get_versions.py
+++ b/src/git/long_get_versions.py
@@ -31,7 +31,8 @@ def get_versions():
         for i in cfg.versionfile_source.split('/'):
             root = os.path.dirname(root)
     except NameError:
-        return {"version": "0+unknown", "full-revisionid": None,
+        return {"version": fallback_version + "+unknown",
+                "full-revisionid": None,
                 "dirty": None,
                 "error": "unable to find root of source tree",
                 "date": None}
@@ -48,6 +49,7 @@ def get_versions():
     except NotThisMethod:
         pass
 
-    return {"version": "0+unknown", "full-revisionid": None,
+    return {"version": fallback_version + "+unknown",
+            "full-revisionid": None,
             "dirty": None,
             "error": "unable to compute version", "date": None}

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import sys
 
+fallback_version = "0"
 
 def get_keywords():
     """Get the keywords needed to look up the version information."""
@@ -64,5 +65,3 @@ def register_vcs_handler(vcs, method):  # decorator
         HANDLERS[vcs][method] = f
         return f
     return decorate
-
-

--- a/src/render.py
+++ b/src/render.py
@@ -13,7 +13,8 @@ def render_pep440(pieces):
     get a tagged build and then dirty it, you'll get TAG+0.gHEX.dirty
 
     Exceptions:
-    1: no tags. git_describe was just HEX. 0+untagged.DISTANCE.gHEX[.dirty]
+    1: no tags. git_describe was just HEX.
+       fallback_version+untagged.DISTANCE.gHEX[.dirty]
     """
     if pieces["closest-tag"]:
         rendered = pieces["closest-tag"]
@@ -24,8 +25,9 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = (fallback_version +
+                    ("+untagged.%d.g%s" % (pieces["distance"],
+                                           pieces["short"])))
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -166,4 +168,3 @@ def render(pieces, style):
     return {"version": rendered, "full-revisionid": pieces["long"],
             "dirty": pieces["dirty"], "error": None,
             "date": pieces.get("date")}
-

--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -119,14 +119,14 @@ class Keywords(unittest.TestCase):
 
     def test_no_tags(self):
         v = self.parse("(HEAD, master)", "full")
-        self.assertEqual(v["version"], "0+unknown")
+        self.assertEqual(v["version"], fallback_version + "+unknown")
         self.assertEqual(v["full-revisionid"], "full")
         self.assertEqual(v["dirty"], False)
         self.assertEqual(v["error"], "no suitable tags")
 
     def test_no_prefix(self):
         v = self.parse("(HEAD, master, 1.23)", "full", "missingprefix-")
-        self.assertEqual(v["version"], "0+unknown")
+        self.assertEqual(v["version"], fallback_version + "+unknown")
         self.assertEqual(v["full-revisionid"], "full")
         self.assertEqual(v["dirty"], False)
         self.assertEqual(v["error"], "no suitable tags")


### PR DESCRIPTION
First attempt at resolving #140.

I know it is against the spirit of versioneer, but at least users will get some semblance of a version if they accidentally download the zip/tar from something that doesn't use git-archive. 

I think the general idea of giving maintainers breathing room in case they forget to update the constant.

I don't know if this is in the "spirit" of versioneer.