### PR TITLE
STY: Centralize pylint hints in header

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,19 +85,6 @@ class make_versioneer(Command):
         pass
     def run(self):
         with open("versioneer.py", "w") as f:
-            f.write("# pylint:disable=trailing-whitespace\n")
-            f.write("# pylint:disable=invalid-name\n")
-            f.write("# pylint:disable=import-outside-toplevel\n")
-            f.write("# pylint:disable=missing-function-docstring\n")
-            f.write("# pylint:disable=missing-class-docstring\n")
-            f.write("# pylint:disable=too-many-branches\n")
-            f.write("# pylint:disable=too-many-statements\n")
-            f.write("# pylint:disable=raise-missing-from\n")
-            f.write("# pylint:disable=too-many-lines\n")
-            f.write("# pylint:disable=too-many-locals\n")
-            f.write("# pylint:disable=too-few-public-methods\n")
-            f.write("# pylint:disable=import-error\n")
-            f.write("# pylint:disable=redefined-outer-name\n")
             f.write(generate_versioneer_py().decode("utf8"))
         return 0
 

--- a/src/cmdclass.py
+++ b/src/cmdclass.py
@@ -187,7 +187,6 @@ def get_cmdclass(cmdclass=None):
     class cmd_sdist(_sdist):
         def run(self):
             versions = get_versions()
-            # pylint:disable=attribute-defined-outside-init # noqa
             self._versioneer_generated_versions = versions
             # unless we update this, the command will keep using the old
             # version

--- a/src/git/long_header.py
+++ b/src/git/long_header.py
@@ -29,7 +29,7 @@ def get_keywords():
     return keywords
 
 
-class VersioneerConfig:  # pylint: disable=too-few-public-methods
+class VersioneerConfig:
     """Container for Versioneer configuration parameters."""
 
 

--- a/src/header.py
+++ b/src/header.py
@@ -5,6 +5,11 @@
 
 @README@
 """
+# pylint:disable=invalid-name,import-outside-toplevel,missing-function-docstring
+# pylint:disable=missing-class-docstring,too-many-branches,too-many-statements
+# pylint:disable=raise-missing-from,too-many-lines,too-many-locals,import-error
+# pylint:disable=too-few-public-methods,redefined-outer-name,consider-using-with
+# pylint:disable=attribute-defined-outside-init,too-many-arguments
 
 import configparser
 import errno
@@ -15,7 +20,7 @@ import subprocess
 import sys
 
 
-class VersioneerConfig:  # pylint: disable=too-few-public-methods # noqa
+class VersioneerConfig:
     """Container for Versioneer configuration parameters."""
 
 
@@ -73,7 +78,6 @@ def get_config_from_root(root):
     # Dict-like interface for non-mandatory entries
     section = parser["versioneer"]
 
-    # pylint:disable=attribute-defined-outside-init # noqa
     cfg = VersioneerConfig()
     cfg.VCS = VCS
     cfg.style = section.get("style", "")

--- a/src/subprocess_helper.py
+++ b/src/subprocess_helper.py
@@ -1,5 +1,4 @@
 import sys, subprocess, errno # --STRIP DURING BUILD
-# pylint:disable=too-many-arguments,consider-using-with # noqa
 def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
                 env=None):
     """Call the given command(s)."""


### PR DESCRIPTION
Did not pay enough attention during the pylint PRs. We ended up with a mix of narrow and broad disables, including some before the module docstring. This centralizes them to a single place, under the docstring, consuming only 5 lines.