### PR TITLE
Use consistent hash length

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -283,7 +283,7 @@ def git_pieces_from_vcs(
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = runner(GITS, [
-        "describe", "--tags", "--dirty", "--always", "--long",
+        "describe", "--tags", "--dirty", "--always", "--long", "--abbrev=7",
         "--match", f"{tag_prefix}[[:digit:]]*"
     ], cwd=root)
     # --long was added in git-1.5.5

--- a/src/git/from_vcs.py
+++ b/src/git/from_vcs.py
@@ -41,7 +41,7 @@ def git_pieces_from_vcs(
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = runner(GITS, [
-        "describe", "--tags", "--dirty", "--always", "--long",
+        "describe", "--tags", "--dirty", "--always", "--long", "--abbrev=7",
         "--match", f"{tag_prefix}[[:digit:]]*"
     ], cwd=root)
     # --long was added in git-1.5.5


### PR DESCRIPTION
Fixes #156 by always using `--abbrev=7` in `git describe` calls to ensure hashes are consistent.

I went with 7 characters, because that's also the length used when using `git rev-parse --short HEAD` when `describe` is not available.

This will make sure that the version strings generated by `versioneer` are consistent across different machines and environments.

(I recently ran into an issue with a development version of `dask` where the short hash varied between environments)
