### PR TITLE
Replace pkg_resources parse_version in Git test

### DIFF
--- a/test/git/test_git.py
+++ b/test/git/test_git.py
@@ -10,7 +10,7 @@ import re
 from unittest import mock
 from pathlib import Path
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 sys.path.insert(0, "src")
 import common


### PR DESCRIPTION
## Summary
- use `packaging.version.parse` in the Git test instead of the removed `pkg_resources.parse_version`
- rely on the existing `packaging>=20` tox dependency

Fixes #414

## Validation
- `git diff --check`
- `git diff --cached --check`
- `git diff --check HEAD~1..HEAD`
- Not run locally

## Remote CI
- `Tox` run 26342344094 completed with `bootstrap` and `build` passing.
- The `test*` jobs failed in `test/git/test_invocations.py` around `setup.py develop` / isolated pip installs (`--find-links` handling and missing `setuptools>=40.8.0` in local links).
- Recent `master` `Tox` runs 26009541783 and 26010403410 are also failing on the same workflow, so this does not appear to be caused by the one-line import replacement in this PR.
