### PR TITLE
Document pyproject dynamic version setting

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,6 +99,16 @@ To versioneer-enable your project:
   parentdir_prefix = myproject-
   ```
 
+  If your project uses setuptools metadata in `pyproject.toml`, declare the
+  version field as dynamic so setuptools knows Versioneer supplies it:
+
+  ```toml
+  [project]
+  dynamic = ["version"]
+  ```
+
+  Do not also set a fixed `version` value in `[project]`.
+
 * 3: If using the EXPERIMENTAL non-vendored mode, add `versioneer` to your
   `pyproject.toml`:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ is intended to allow you to skip this step and simplify the process of upgrading
   `[versioneer]` section to your `setup.cfg` (see [Install](INSTALL.md))
    * Note that you will need to add `tomli; python_version < "3.11"` to your
      build-time dependencies if you use `pyproject.toml`
+   * If your setuptools metadata is in `pyproject.toml`, set
+     `dynamic = ["version"]` in the `[project]` table instead of providing a
+     fixed `version`.
 * run `versioneer install --vendor` in your source tree, commit the results
 * verify version information with `python setup.py version`
 
@@ -48,6 +51,9 @@ is intended to allow you to skip this step and simplify the process of upgrading
   requires = ["setuptools", "versioneer[toml]"]
   build-backend = "setuptools.build_meta"
   ```
+* if your setuptools metadata is in `pyproject.toml`, set
+  `dynamic = ["version"]` in the `[project]` table instead of providing a fixed
+  `version`.
 * run `versioneer install --no-vendor` in your source tree, commit the results
 * verify version information with `python setup.py version`
 


### PR DESCRIPTION
## Summary
- document that projects using setuptools metadata in `pyproject.toml` should declare `dynamic = [version]`
- add the note to the quick install guide and the detailed installation steps

Closes #370

## Validation
- Not run locally
- Static validation only: `git diff --check`